### PR TITLE
Update stunner.yaml

### DIFF
--- a/deploy/manifests/stunner.yaml
+++ b/deploy/manifests/stunner.yaml
@@ -33,22 +33,22 @@ data:
   # * `STUNNER_AUTH_TYPE` (default: `plaintext`): the STUN/TURN authentication mode, either
   #   "plaintext" over the username/password pair $STUNNER_USERNAME/$STUNNER_PASSWORD, or
   #   "longterm", using $STUNNER_SECRET. Make sure to customize!
-  STUNNER_AUTH_TYPE: plaintext
+  STUNNER_AUTH_TYPE: "plaintext"
 
   # * `STUNNER_USERNAME` (default: `user`): the USERNAME attribute clients can use the authenticate
   #    with STUNner over plain-text authentication. Make sure to customize!
-  STUNNER_USERNAME: user1
+  STUNNER_USERNAME: "user1"
 
   # * `STUNNER_PASSWORD` (default: `pass`): the password clients can use to authenticate with
   #   STUNner over plain-text authentication. Make sure to customize!
-  STUNNER_PASSWORD: passwd1
+  STUNNER_PASSWORD: "passwd1"
 
   # * `STUNNER_SHARED_SECRET`: the shared secret used for longterm authentication.
   STUNNER_SHARED_SECRET: "my-shared-secret"
 
   # * `STUNNER_DURATION` (default: `86400`, i.e., one day): the lifetime of STUNner credentials
   # * over longterm authentication.
-  STUNNER_DURATION: 86400
+  STUNNER_DURATION: "86400"
 
   # * `STUNNER_LOGLEVEL` (default: `all:WARN`): the default log level used by the STUNner daemons.
   STUNNER_LOGLEVEL: "all:INFO"


### PR DESCRIPTION
k3s(and maybe others) implementation requires that values in configMaps are surrounded by quotes otherwise an error will be thrown. This change will add quotes on all configMap default values to make it compatible with k3s and other implementations with similar requirements.