### PR TITLE
Fix namespace issue

### DIFF
--- a/cmd/post-install/post-install.yaml
+++ b/cmd/post-install/post-install.yaml
@@ -44,7 +44,7 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     crb: stunner-job
-  name: prometheus-operator
+  name: stunner-job
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/helm/stunner/templates/post-install-job.yaml
+++ b/helm/stunner/templates/post-install-job.yaml
@@ -50,7 +50,7 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     crb: stunner-job
-  name: prometheus-operator
+  name: stunner-job
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -58,5 +58,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ .Values.stunner.postInstall.serviceAccountName }}
-  namespace: default
+  namespace: {{ .Values.stunner.namespace }}
 ---


### PR DESCRIPTION
fixing namespace issue that prevented the helm chart to be installed in namespaces other than `default` 