### PR TITLE
Kurento magic mirror example with STUNner

### DIFF
--- a/examples/kurento-magic-mirror/README.md
+++ b/examples/kurento-magic-mirror/README.md
@@ -15,8 +15,7 @@ installed into a standard Kubernetes cluster.
 In this demo you will learn the following steps to:
 * integrate a typical WebRTC application server to be used with STUNner,
 * deploy the modified application server into a Kubernetes,
-* deploy the Kurento media server into Kubernetes behind STUNner,
-* secure a STUNner deployment, and
+* deploy the Kurento media server into Kubernetes behind STUNner, 
 * scale a standard WebRTC workload using Kubernetes and STUNner.
 
 ## Installation
@@ -31,10 +30,28 @@ The simplest way to deploy the demo is to clone the [STUNner git
 repository](https://github.com/l7mp/stunner) and deploy the
 [manifest](kurento-magic-mirror.yaml) packaged with STUNner.
 
+Install the STUNner gateway operator and STUNner ([more info](https://github.com/l7mp/stunner-helm)):
+```console
+helm repo add stunner https://l7mp.io/stunner
+helm repo update
+
+helm install stunner-gateway-operator stunner/stunner-gateway-operator
+
+helm install stunner stunner/stunner
+```
+
+Install the WebRTC application and Kurento media servers, altogether with the corresponding services and Kubernetes objects (see the content of the yaml for details):
 ```console
 $ git clone https://github.com/l7mp/stunner
 $ cd stunner
-$ kubectl apply -f examples/kurento-magic-mirror/kurento-magic-mirror.yaml
+$ kubectl apply -f examples/kurento-magic-mirror/kurento-magic-mirror-server.yaml
+```
+
+### Configuration 
+Configure STUNner to act as a STUN server towards clients, and to let media reach the media server.
+
+```console
+$ kubectl apply -f examples/kurento-magic-mirror/kurento-magic-mirror-stunner.yaml
 ```
 
 The demo exposes a publicly available HTTPS web service on port 8443. Kubernetes assigns an
@@ -47,7 +64,7 @@ $ kubectl get service webrtc-server -n default -o jsonpath='{.status.loadBalance
 The result should be a valid IP address in the form `A.B.C.D`. If no IP address is returned, wait a
 bit more until Kubernetes successfully assigns the external IP. Then, direct your browser to the
 URL `https://<A.B.C.D>:8443` (of course, make sure substitute the previous IP address), accept the
-self-signed certificate, register some user name, and you can immediately enjoy the demo.
+self-signed certificate, and hit the `Start` button.
 
 ### Scaling
 

--- a/examples/kurento-magic-mirror/kurento-magic-mirror-server.yaml
+++ b/examples/kurento-magic-mirror/kurento-magic-mirror-server.yaml
@@ -58,12 +58,18 @@ spec:
             value: ""
         ports:
         - containerPort: 8888
+        resources:
+          requests:
+            cpu: "100m"
+          limits:
+            cpu: "1000m"
+
       # Uncomment this if you want to deploy a sidecar container to sniff traffic
       # - name: net-debug
       #   image: l7mp/net-debug:latest
       #   command: ["/bin/sh"]
       #   args: ["-c", "while true; do echo hello; sleep 10;done"]
-            
+
 ---
 apiVersion: v1
 kind: Service
@@ -97,24 +103,38 @@ spec:
     spec:
       containers:
       - name: webrtc-server
-        image: l7mp/kurento-magic-mirror-server
+        # image: l7mp/kurento-magic-mirror-server TODO update
+        image: nmate/kurento-magic-mirror-server:latest
         command: ["npm"]
         args: ["start", "--", "--as_uri=https://0.0.0.0:8443", "--ws_uri=ws://kms-control.default.svc.cluster.local:8888/kurento"]
-        # imagePullPolicy: Never
+        imagePullPolicy: Always
         # command: ["/bin/sh"]
         # args: ["-c", "while true; do echo hello; sleep 10;done"]
-        imagePullPolicy: Always
+        # imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8443
         # TURN server config to return to the user
-        envFrom:
-          - configMapRef:
-              name: stunner-config
+        env:
+          - name: STUNNER_CONFIG_FILENAME
+            value: "/etc/stunnerd/stunnerd.conf"
         volumeMounts:
           - name: webrtc-server-tls
             mountPath: "/app/keys"
             readOnly: true
+          - name: stunnerd-config-volume
+            mountPath: "/etc/stunnerd"
+            readOnly: true
+
+      # - name: net-debug
+      #   image: l7mp/net-debug:latest
+      #   command: ["/bin/sh"]
+      #   args: ["-c", "while true; do echo hello; sleep 10;done"]
+
       volumes:
+        - name: stunnerd-config-volume
+          configMap:
+            name: stunnerd-config
+            optional: true
         - name: webrtc-server-tls
           secret:
             secretName: webrtc-server-secret
@@ -141,6 +161,25 @@ spec:
       name: webrtc-server-port
 
 ---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: kms-media-plane
+  namespace: default
+  labels:
+    app: kms-media-plane
+spec:
+  ports:
+    # port is ignored in the below
+    - port: 9999
+      protocol: UDP
+      name: kms-media-plane-port
+  selector:
+    app: kms
+
+---
+
 # for serving the overlay image to Kurento
 apiVersion: v1
 kind: Service
@@ -156,25 +195,3 @@ spec:
       protocol: TCP
       name: overlay-image-port
 
----
-# lock down access from the TURN server only to kms
-apiVersion: networking.k8s.io/v1
-kind: NetworkPolicy
-metadata:
-  name: stunner-network-policy
-  namespace: default
-spec:
-  podSelector:
-    matchLabels:
-      app: stunner
-  policyTypes:
-  - Egress
-  egress:
-  - to:
-    - podSelector:
-        matchLabels:
-          app: kms
-    ports:
-    - protocol: UDP
-      port: 10000
-      endPort: 20000

--- a/examples/kurento-magic-mirror/kurento-magic-mirror-stunner.yaml
+++ b/examples/kurento-magic-mirror/kurento-magic-mirror-stunner.yaml
@@ -1,0 +1,51 @@
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: GatewayClass
+metadata:
+  name: stunner-gatewayclass
+spec:
+  controllerName: "stunner.l7mp.io/gateway-operator"
+  parametersRef:
+    group: "stunner.l7mp.io"
+    kind: GatewayConfig
+    name: stunner-gatewayconfig
+    namespace: default
+  description: "STUNner is a WebRTC ingress gateway for Kubernetes"
+
+---
+apiVersion: stunner.l7mp.io/v1alpha1
+kind: GatewayConfig
+metadata:
+  name: stunner-gatewayconfig
+  namespace: default
+spec:
+  realm: stunner.l7mp.io
+  authType: plaintext
+  userName: "user-1"
+  password: "pass-1"
+
+---
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: Gateway
+metadata:
+  name: udp-gateway
+  namespace: default
+spec:
+  gatewayClassName: stunner-gatewayclass
+  listeners:
+    - name: udp-listener
+      port: 3478
+      protocol: UDP
+
+---
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: UDPRoute
+metadata:
+  name: media-plane
+  namespace: default
+spec:
+  parentRefs:
+    - name: udp-gateway
+  rules:
+    - backendRefs:
+        - name: kms-media-plane
+          namespace: default


### PR DESCRIPTION
TODO: switch the link to the l7mp docker registry whenever the webrtc server
Docker image is built and pushed.