### PR TITLE
examples/cloudretro: Link multicluster videos in README

### DIFF
--- a/examples/cloudretro/README.md
+++ b/examples/cloudretro/README.md
@@ -213,6 +213,10 @@ Although, you can manually choose workers by clicking the little `w` button unde
 For example, two videos are included. Both were recorded from a client in the European region with 240 FPS.
 It is obvious, that the one made with an US-region worker (48 frame ~200,00ms) has latency between invoke and response much larger than in the European one (20 frame ~83,33ms).
 
+| US video | EU video |
+|---|---|
+![cloudretro_us.mp4](cloudretro_us.mp4) | ![cloudretro_eu.mp4](cloudretro_eu.mp4) |
+
 
 ## Clean up
 

--- a/examples/cloudretro/README.md
+++ b/examples/cloudretro/README.md
@@ -215,7 +215,7 @@ It is obvious, that the one made with an US-region worker (48 frame ~200,00ms) h
 
 | US video | EU video |
 |---|---|
-![cloudretro_us.mp4](cloudretro_us.mp4) | ![cloudretro_eu.mp4](cloudretro_eu.mp4) |
+| ![cloudretro_us.mp4](https://github.com/l7mp/stunner/raw/main/examples/cloudretro/cloudretro_us.mp4) | ![cloudretro_eu.mp4](https://github.com/l7mp/stunner/raw/main/examples/cloudretro/cloudretro_eu.mp4) |
 
 
 ## Clean up


### PR DESCRIPTION
This PR add links to the uploaded multicluster videos, however, it would best to embed them somehow.. 