### PR TITLE
doc: Bump copyright year

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 l7mp
+Copyright (c) 2023 l7mp
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -606,7 +606,7 @@ STUNner development is coordinated in Discord, feel free to [join](https://disco
 
 ## License
 
-Copyright 2021-2022 by its authors. Some rights reserved. See [AUTHORS](AUTHORS).
+Copyright 2021-2023 by its authors. Some rights reserved. See [AUTHORS](AUTHORS).
 
 MIT License - see [LICENSE](LICENSE) for full text.
 

--- a/cmd/stunnerctl/README.md
+++ b/cmd/stunnerctl/README.md
@@ -18,6 +18,6 @@ Public port:	3478
 
 ## License
 
-Copyright 2021-2022 by its authors. Some rights reserved. See [AUTHORS](../../AUTHORS).
+Copyright 2021-2023 by its authors. Some rights reserved. See [AUTHORS](../../AUTHORS).
 
 MIT License - see [LICENSE](../../LICENSE) for full text.

--- a/cmd/stunnerd/README.md
+++ b/cmd/stunnerd/README.md
@@ -110,7 +110,7 @@ static:
 
 ## License
 
-Copyright 2021-2022 by its authors. Some rights reserved. See [AUTHORS](../../AUTHORS).
+Copyright 2021-2023 by its authors. Some rights reserved. See [AUTHORS](../../AUTHORS).
 
 MIT License - see [LICENSE](../../LICENSE) for full text.
 

--- a/cmd/turncat/README.md
+++ b/cmd/turncat/README.md
@@ -49,7 +49,7 @@ enable verbose logging.
 
 ## License
 
-Copyright 2021-2022 by its authors. Some rights reserved. See [AUTHORS](../../AUTHORS).
+Copyright 2021-2023 by its authors. Some rights reserved. See [AUTHORS](../../AUTHORS).
 
 MIT License - see [LICENSE](../../LICENSE) for full text.
 

--- a/doc/AUTH.md
+++ b/doc/AUTH.md
@@ -198,7 +198,7 @@ STUNner development is coordinated in Discord, feel free to [join](https://disco
 
 ## License
 
-Copyright 2021-2022 by its authors. Some rights reserved. See [AUTHORS](../AUTHORS).
+Copyright 2021-2023 by its authors. Some rights reserved. See [AUTHORS](../AUTHORS).
 
 MIT License - see [LICENSE](../LICENSE) for full text.
 

--- a/doc/CONCEPTS.md
+++ b/doc/CONCEPTS.md
@@ -79,7 +79,7 @@ STUNner development is coordinated in Discord, feel free to [join](https://disco
 
 ## License
 
-Copyright 2021-2022 by its authors. Some rights reserved. See [AUTHORS](../AUTHORS).
+Copyright 2021-2023 by its authors. Some rights reserved. See [AUTHORS](../AUTHORS).
 
 MIT License - see [LICENSE](../LICENSE) for full text.
 

--- a/doc/DEPLOYMENT.md
+++ b/doc/DEPLOYMENT.md
@@ -136,7 +136,7 @@ STUNner development is coordinated in Discord, feel free to [join](https://disco
 
 ## License
 
-Copyright 2021-2022 by its authors. Some rights reserved. See [AUTHORS](../AUTHORS).
+Copyright 2021-2023 by its authors. Some rights reserved. See [AUTHORS](../AUTHORS).
 
 MIT License - see [LICENSE](../LICENSE) for full text.
 

--- a/doc/GATEWAY.md
+++ b/doc/GATEWAY.md
@@ -330,7 +330,7 @@ STUNner development is coordinated in Discord, feel free to [join](https://disco
 
 ## License
 
-Copyright 2021-2022 by its authors. Some rights reserved. See [AUTHORS](../AUTHORS).
+Copyright 2021-2023 by its authors. Some rights reserved. See [AUTHORS](../AUTHORS).
 
 MIT License - see [LICENSE](../LICENSE) for full text.
 

--- a/doc/INSTALL.md
+++ b/doc/INSTALL.md
@@ -81,7 +81,7 @@ STUNner development is coordinated in Discord, feel free to [join](https://disco
 
 ## License
 
-Copyright 2021-2022 by its authors. Some rights reserved. See [AUTHORS](../AUTHORS).
+Copyright 2021-2023 by its authors. Some rights reserved. See [AUTHORS](../AUTHORS).
 
 MIT License - see [LICENSE](../LICENSE) for full text.
 

--- a/doc/MONITORING.md
+++ b/doc/MONITORING.md
@@ -74,7 +74,7 @@ STUNner development is coordinated in Discord, feel free to [join](https://disco
 
 ## License
 
-Copyright 2021-2022 by its authors. Some rights reserved. See [AUTHORS](../AUTHORS).
+Copyright 2021-2023 by its authors. Some rights reserved. See [AUTHORS](../AUTHORS).
 
 MIT License - see [LICENSE](../LICENSE) for full text.
 

--- a/doc/OBSOLETE.md
+++ b/doc/OBSOLETE.md
@@ -501,7 +501,7 @@ STUNner development is coordinated in Discord, feel free to [join](https://disco
 
 ## License
 
-Copyright 2021-2022 by its authors. Some rights reserved. See [AUTHORS](../AUTHORS).
+Copyright 2021-2023 by its authors. Some rights reserved. See [AUTHORS](../AUTHORS).
 
 MIT License - see [LICENSE](../LICENSE) for full text.
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -56,6 +56,6 @@ STUNner development is coordinated in Discord, feel free to [join](https://disco
 
 ## License
 
-Copyright 2021-2022 by its authors. Some rights reserved. See [AUTHORS](/AUTHORS).
+Copyright 2021-2023 by its authors. Some rights reserved. See [AUTHORS](/AUTHORS).
 
 MIT License - see [LICENSE](/LICENSE) for full text.

--- a/doc/SECURITY.md
+++ b/doc/SECURITY.md
@@ -210,7 +210,7 @@ STUNner development is coordinated in Discord, feel free to [join](https://disco
 
 ## License
 
-Copyright 2021-2022 by its authors. Some rights reserved. See [AUTHORS](../AUTHORS).
+Copyright 2021-2023 by its authors. Some rights reserved. See [AUTHORS](../AUTHORS).
 
 MIT License - see [LICENSE](../LICENSE) for full text.
 

--- a/doc/WHY.md
+++ b/doc/WHY.md
@@ -115,7 +115,7 @@ STUNner development is coordinated in Discord, feel free to [join](https://disco
 
 ## License
 
-Copyright 2021-2022 by its authors. Some rights reserved. See [AUTHORS](../AUTHORS).
+Copyright 2021-2023 by its authors. Some rights reserved. See [AUTHORS](../AUTHORS).
 
 MIT License - see [LICENSE](../LICENSE) for full text.
 

--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -184,6 +184,6 @@ STUNner development is coordinated in Discord, feel free to [join](https://disco
 
 ## License
 
-Copyright 2021-2022 by its authors. Some rights reserved. See [AUTHORS](../../AUTHORS).
+Copyright 2021-2023 by its authors. Some rights reserved. See [AUTHORS](../../AUTHORS).
 
 MIT License - see [LICENSE](../../LICENSE) for full text.

--- a/examples/cloudretro/README.md
+++ b/examples/cloudretro/README.md
@@ -248,7 +248,7 @@ STUNner development is coordinated in Discord, feel free to [join](https://disco
 
 ## License
 
-Copyright 2021-2022 by its authors. Some rights reserved. See [AUTHORS](../../AUTHORS).
+Copyright 2021-2023 by its authors. Some rights reserved. See [AUTHORS](../../AUTHORS).
 
 MIT License - see [LICENSE](../../LICENSE) for full text.
 

--- a/examples/direct-one2one-call/README.md
+++ b/examples/direct-one2one-call/README.md
@@ -398,7 +398,7 @@ STUNner development is coordinated in Discord, feel free to [join](https://disco
 
 ## License
 
-Copyright 2021-2022 by its authors. Some rights reserved. See [AUTHORS](../../AUTHORS).
+Copyright 2021-2023 by its authors. Some rights reserved. See [AUTHORS](../../AUTHORS).
 
 MIT License - see [LICENSE](../../LICENSE) for full text.
 

--- a/examples/jitsi/README.md
+++ b/examples/jitsi/README.md
@@ -208,6 +208,6 @@ STUNner development is coordinated in Discord, feel free to [join](https://disco
 
 ## License
 
-Copyright 2021-2022 by its authors. Some rights reserved. See [AUTHORS](../../AUTHORS).
+Copyright 2021-2023 by its authors. Some rights reserved. See [AUTHORS](../../AUTHORS).
 
 MIT License - see [LICENSE](../../LICENSE) for full text.

--- a/examples/kurento-magic-mirror/README.md
+++ b/examples/kurento-magic-mirror/README.md
@@ -85,7 +85,7 @@ STUNner development is coordinated in Discord, feel free to [join](https://disco
 
 ## License
 
-Copyright 2021-2022 by its authors. Some rights reserved. See [AUTHORS](../../AUTHORS).
+Copyright 2021-2023 by its authors. Some rights reserved. See [AUTHORS](../../AUTHORS).
 
 MIT License - see [LICENSE](../../LICENSE) for full text.
 

--- a/examples/kurento-one2one-call/README.md
+++ b/examples/kurento-one2one-call/README.md
@@ -495,7 +495,7 @@ STUNner development is coordinated in Discord, feel free to [join](https://disco
 
 ## License
 
-Copyright 2021-2022 by its authors. Some rights reserved. See [AUTHORS](../../AUTHORS).
+Copyright 2021-2023 by its authors. Some rights reserved. See [AUTHORS](../../AUTHORS).
 
 MIT License - see [LICENSE](../../LICENSE) for full text.
 

--- a/examples/livekit/README.md
+++ b/examples/livekit/README.md
@@ -235,6 +235,6 @@ STUNner development is coordinated in Discord, feel free to [join](https://disco
 
 ## License
 
-Copyright 2021-2022 by its authors. Some rights reserved. See [AUTHORS](../../AUTHORS).
+Copyright 2021-2023 by its authors. Some rights reserved. See [AUTHORS](../../AUTHORS).
 
 MIT License - see [LICENSE](../../LICENSE) for full text.

--- a/examples/neko/README.md
+++ b/examples/neko/README.md
@@ -73,7 +73,7 @@ STUNner development is coordinated in Discord, feel free to [join](https://disco
 
 ## License
 
-Copyright 2021-2022 by its authors. Some rights reserved. See [AUTHORS](../../AUTHORS).
+Copyright 2021-2023 by its authors. Some rights reserved. See [AUTHORS](../../AUTHORS).
 
 MIT License - see [LICENSE](../../LICENSE) for full text.
 

--- a/examples/simple-tunnel/README.md
+++ b/examples/simple-tunnel/README.md
@@ -244,6 +244,6 @@ STUNner development is coordinated in Discord, feel free to [join](https://disco
 
 ## License
 
-Copyright 2021-2022 by its authors. Some rights reserved. See [AUTHORS](../../AUTHORS).
+Copyright 2021-2023 by its authors. Some rights reserved. See [AUTHORS](../../AUTHORS).
 
 MIT License - see [LICENSE](../../LICENSE) for full text.


### PR DESCRIPTION
As the title says, this PR bumps the year in License sections of all documents.

---

<details>
<summary>One-liner for next year:</summary>

```console
find . -type f | xargs sed -i  's/Copyright 2021-2023/Copyright 2021-2024/g'
```
</details>