### PR TITLE
chore(CI/CD): Bump Go version to 1.19

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version: 1.19
       - name: Checkout code
         uses: actions/checkout@v3
       - name: Run linters

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version: 1.19
       - name: Download modules
         run: go mod download
       - name: Go install
@@ -35,7 +35,7 @@ jobs:
         if: success()
         uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version: 1.19
       - name: Checkout code
         uses: actions/checkout@v3
       - name: Calc coverage

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ###########
 # BUILD
-FROM golang:1.18-alpine as builder
+FROM golang:1.19-alpine as builder
 
 WORKDIR /app
 


### PR DESCRIPTION
As of the Go [release policy](https://go.dev/doc/devel/release), Go 1.18 is reaching its end of life. Accordingly, this PR bumps Go version in CI/CD pipelines and in the Dockerfile.