### PR TITLE
chore(CI): Propagate helm updates to l7mp/stunner-helm

### DIFF
--- a/.github/workflows/publish-dev.yaml
+++ b/.github/workflows/publish-dev.yaml
@@ -1,6 +1,7 @@
 name: "release-dev"
 
 on:
+  workflow_dispatch:
   push:
     paths:
       - '**.go'

--- a/.github/workflows/publish-dev.yaml
+++ b/.github/workflows/publish-dev.yaml
@@ -31,43 +31,16 @@ jobs:
     name: Push charts to the web
     runs-on: ubuntu-latest
     steps:
-      - name: stunner checkout
-        uses: actions/checkout@v3
+
+      - name: Get the version
+        id: vars
+        run: echo ::set-output name=tag::$(echo ${GITHUB_REF:11})
+
+      - name: Triggering release workflow in the stunner-helm repo
+        uses: convictional/trigger-workflow-and-wait
         with:
-          path: stunner
-          ref: main
-          repository: l7mp/stunner
-      - name: l7mp.io checkout
-        uses: actions/checkout@v3
-        with:
-          token: ${{ secrets.WEB_PAT_TOKEN }}
-          path: l7mp.io
-          ref: master
-          repository: l7mp/l7mp.io
-      - name: stunner-helm checkout
-        uses: actions/checkout@v3
-        with:
-          token: ${{ secrets.WEB_PAT_TOKEN }}
-          path: stunner-helm
-          ref: main
-          repository: l7mp/stunner-helm
-      - name: Set git config
-        run: |
-          git config --global user.email "l7mp.info@gmail.com"
-          git config --global user.name "BotL7mp"
-      - name: Build helm charts
-        run: |
-          cd stunner-helm/helm
-          sed -ri 's/^(\s*)(name\s*:\s*.*\s*$)/\1name: stunner-dev/' stunner/Chart.yaml
-          sed -ri 's/^(\s*)(appVersion\s*:\s*.*\s*$)/\1appVersion: dev/' stunner/Chart.yaml
-          sed -ri 's/^(\s*)(        tag\s*:\s*.*\s*$)/\1        tag: dev/' stunner/values.yaml
-          helm package ./stunner
-      - name: Update l7mp.io
-        run: |
-          rm -rf l7mp.io/stunner/stunner-dev*.tgz
-          cp stunner-helm/helm/*.tgz l7mp.io/stunner
-          helm repo index l7mp.io/stunner/ --url https://l7mp.io/stunner
-          cd l7mp.io
-          git add .
-          git commit -m "Update dev helm chart from l7mp/stunner" -m "(triggered by the 'Helm release' github action.)"
-          git push origin master
+          github_token: ${{ secrets.WEB_PAT_TOKEN }}
+          owner: l7mp
+          repo: stunner-helm
+          client_payload: '{"tag": "dev", "type": "stunner"}'
+          workflow_file_name: publish.yaml

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,9 +36,8 @@ jobs:
       - name: Triggering release workflow in the stunner-helm repo
         uses: convictional/trigger-workflow-and-wait
         with:
-          github-token: ${{ secrets.WEB_PAT_TOKEN }}
+          github_token: ${{ secrets.WEB_PAT_TOKEN }}
           owner: l7mp
           repo: stunner-helm
-          event-type: release
           client_payload: '{"tag": "${{steps.vars.outputs.tag}}", "type": "stunner"}'
           workflow_file_name: publish.yaml

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,52 +28,15 @@ jobs:
     name: Push charts to the web
     runs-on: ubuntu-latest
     steps:
-      - name: stunner checkout
-        uses: actions/checkout@v3
-        with:
-          path: stunner
-          ref: main
-          repository: l7mp/stunner
+
       - name: Get the version
         id: vars
         run: echo ::set-output name=tag::$(echo ${GITHUB_REF:11})
-      - name: l7mp.io checkout
-        uses: actions/checkout@v3
+
+      - name: Repository dispatch with passing the tagged version
+        uses: peter-evans/repository-dispatch@v2.1.1
         with:
           token: ${{ secrets.WEB_PAT_TOKEN }}
-          path: l7mp.io
-          ref: master
-          repository: l7mp/l7mp.io
-      - name: stunner-helm checkout
-        uses: actions/checkout@v3
-        with:
-          token: ${{ secrets.WEB_PAT_TOKEN }}
-          path: stunner-helm
-          ref: main
           repository: l7mp/stunner-helm
-      - name: Set git config
-        run: |
-          git config --global user.email "l7mp.info@gmail.com"
-          git config --global user.name "BotL7mp"
-      - name: Build helm charts
-        run: |
-          cd stunner-helm/helm
-          sed -ri 's/^(\s*)(version\s*:\s*.*\s*$)/\1version: ${{steps.vars.outputs.tag}}/' stunner/Chart.yaml
-          sed -ri 's/^(\s*)(appVersion\s*:\s*.*\s*$)/\1appVersion: ${{steps.vars.outputs.tag}}/' stunner/Chart.yaml
-          sed -ri 's/^(\s*)(        tag\s*:\s*.*\s*$)/\1        tag: ${{steps.vars.outputs.tag}}/' stunner/values.yaml
-          helm package *
-      - name: Update l7mp.io
-        run: |
-          cp stunner-helm/helm/*.tgz l7mp.io/stunner
-          helm repo index l7mp.io/stunner/ --url https://l7mp.io/stunner
-          cd l7mp.io
-          git add .
-          git commit -m "Update helm charts from l7mp/stunner" -m "(triggered by the 'Helm release' github action.)"
-          git push origin master
-      - name: Update stunner
-        run: |
-          cd stunner-helm
-          rm helm/*.tgz
-          git add .
-          git commit -m "Update helm charts from l7mp/stunner" -m "(triggered by the 'Helm release' github action.)"
-          git push origin main
+          event-type: stunner-release
+          client-payload: '{"tag": "${{steps.vars.outputs.tag}}"}'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,10 +33,12 @@ jobs:
         id: vars
         run: echo ::set-output name=tag::$(echo ${GITHUB_REF:11})
 
-      - name: Repository dispatch with passing the tagged version
-        uses: peter-evans/repository-dispatch@v2.1.1
+      - name: Triggering release workflow in the stunner-helm repo
+        uses: convictional/trigger-workflow-and-wait
         with:
-          token: ${{ secrets.WEB_PAT_TOKEN }}
-          repository: l7mp/stunner-helm
+          github-token: ${{ secrets.WEB_PAT_TOKEN }}
+          owner: l7mp
+          repo: stunner-helm
           event-type: release
-          client-payload: '{"tag": "${{steps.vars.outputs.tag}}", "type": "stunner"}'
+          client_payload: '{"tag": "${{steps.vars.outputs.tag}}", "type": "stunner"}'
+          workflow_file_name: publish.yaml

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,5 +38,5 @@ jobs:
         with:
           token: ${{ secrets.WEB_PAT_TOKEN }}
           repository: l7mp/stunner-helm
-          event-type: stunner-release
+          event-type: release
           client-payload: '{"tag": "${{steps.vars.outputs.tag}}", "type": "stunner"}'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,4 +39,4 @@ jobs:
           token: ${{ secrets.WEB_PAT_TOKEN }}
           repository: l7mp/stunner-helm
           event-type: stunner-release
-          client-payload: '{"tag": "${{steps.vars.outputs.tag}}"}'
+          client-payload: '{"tag": "${{steps.vars.outputs.tag}}", "type": "stunner"}'


### PR DESCRIPTION
WIP DO NOT MERGE YET

Building the chart was moved to the l7mp/stunner-helm repository. In the new version, we use [this](https://github.com/marketplace/actions/repository-dispatch) action. It sends an event to the given repository. A PAT is used to authenticate the request.

- [x] Need to find a way to test 

Testing will happen by manually releasing dev versions. Dev versions are not considered stable, so they shouldn't break anyone's setup. 
Manual releasing with the `workflow_dispatch` event