### PR TITLE
Fix sample Gateway YAML in docs

### DIFF
--- a/doc/GATEWAY.md
+++ b/doc/GATEWAY.md
@@ -133,6 +133,7 @@ kind: Gateway
 metadata:
   name: udp-gateway
   namespace: stunner
+spec:
   gatewayClassName: stunner-gatewayclass
   listeners:
     - name: udp-listener


### PR DESCRIPTION
`spec:` was missing