### PR TITLE
feat(CI/CD): Build arm64 container images

### DIFF
--- a/.github/workflows/publish-dev.yaml
+++ b/.github/workflows/publish-dev.yaml
@@ -54,11 +54,6 @@ jobs:
     name: Push helm charts to the
     runs-on: ubuntu-latest
     steps:
-
-      - name: Get the version
-        id: vars
-        run: echo ::set-output name=tag::$(echo ${GITHUB_REF:11})
-
       - name: Triggering release workflow in the stunner-helm repo
         uses: convictional/trigger-workflow-and-wait@v1.6.5
         with:

--- a/.github/workflows/publish-dev.yaml
+++ b/.github/workflows/publish-dev.yaml
@@ -15,21 +15,43 @@ on:
 
 jobs:
   push_to_registry:
-    name: Push docker image to DockerHub
+    name: Push Docker image to DockerHub
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - name: Login to DockerHub Registry
-        run: echo ${{ secrets.DOCKER_TOKEN }} | docker login -u ${{ secrets.DOCKER_USER }} --password-stdin
-      - name: Get the version
-        id: vars
-        run: echo ::set-output name=tag::$(echo ${GITHUB_REF:11})
-      - name: Build the tagged Docker image
-        run: docker build . --file Dockerfile --tag l7mp/stunnerd:dev
-      - name: Push the tagged Docker image
-        run: docker push l7mp/stunnerd:dev
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: l7mp/stunnerd
+          tags: |
+            type=raw,value=dev
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+
+      - name: Build and Push
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
   push_chart:
-    name: Push charts to the web
+    name: Push helm charts to the
     runs-on: ubuntu-latest
     steps:
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,23 +7,42 @@ on:
 
 jobs:
   push_to_registry:
-    name: Push docker image to DockerHub
+    name: Push Docker image to DockerHub
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - name: Login to DockerHub Registry
-        run: echo ${{ secrets.DOCKER_TOKEN }} | docker login -u ${{ secrets.DOCKER_USER }} --password-stdin
-      - name: Get the version
-        id: vars
-        run: echo ::set-output name=tag::$(echo ${GITHUB_REF:11})
-      - name: Build the tagged Docker image
-        run: docker build . --file Dockerfile --tag l7mp/stunnerd:${{steps.vars.outputs.tag}}
-      - name: Push the tagged Docker image
-        run: docker push l7mp/stunnerd:${{steps.vars.outputs.tag}}
-      - name: Build the latest Docker image
-        run: docker build . --file Dockerfile --tag l7mp/stunnerd:latest
-      - name: Push the latest Docker image
-        run: docker push l7mp/stunnerd:latest
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: l7mp/stunnerd
+          tags: |
+            type=semver,pattern={{version}}
+            type=raw,value=latest
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+
+      - name: Build and Push
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
   push_chart:
     name: Push charts to the web
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -48,9 +48,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-      - name: Get the version
+      - name: Get version
         id: vars
-        run: echo ::set-output name=tag::$(echo ${GITHUB_REF:11})
+        run: echo tag=$(echo ${GITHUB_REF:11}) >> $GITHUB_OUTPUT
 
       - name: Triggering release workflow in the stunner-helm repo
         uses: convictional/trigger-workflow-and-wait@v1.6.5
@@ -58,5 +58,5 @@ jobs:
           github_token: ${{ secrets.WEB_PAT_TOKEN }}
           owner: l7mp
           repo: stunner-helm
-          client_payload: '{"tag": "${{steps.vars.outputs.tag}}", "type": "stunner"}'
+          client_payload: '{"tag": "${{ steps.vars.outputs.tag }}", "type": "stunner"}'
           workflow_file_name: publish.yaml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Convert coverage.out to coverage.lcov
         uses: jandelgado/gcov2lcov-action@v1
       - name: Coveralls
-        uses: coverallsapp/github-action@v1.1.2
+        uses: coverallsapp/github-action@v1
         with:
           github-token: ${{ secrets.github_token }}
           path-to-lcov: coverage.lcov

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,12 @@ COPY pkg/apis/v1alpha1/ pkg/apis/v1alpha1/
 COPY cmd/stunnerd/main.go cmd/stunnerd/
 COPY cmd/stunnerd/stunnerd.conf cmd/stunnerd/
 
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-w -s" -o stunnerd cmd/stunnerd/main.go
+RUN apkArch="$(apk --print-arch)"; \
+      case "$apkArch" in \
+        aarch64) export GOARCH='arm64' ;; \
+        *) export GOARCH='amd64' ;; \
+      esac; \
+    CGO_ENABLED=0 GOOS=linux go build -ldflags="-w -s" -o stunnerd cmd/stunnerd/main.go
 
 ###########
 # STUNNERD


### PR DESCRIPTION
Motivated by #75, this PR adds support for building both arm64 and am64 container images with the workflows.

Note: `dev` tags already have arm64 images:
- https://hub.docker.com/r/l7mp/stunnerd/tags
- https://hub.docker.com/r/l7mp/stunner-gateway-operator/tags
