### PR TITLE
Update CloudRetro helper script

### DIFF
--- a/docs/examples/cloudretro/README.md
+++ b/docs/examples/cloudretro/README.md
@@ -79,14 +79,8 @@ the CloudRetro servers running on a private pod IP address. That is where STUNne
 
 ### STUNner
 
-Use the official [Helm charts](../../INSTALL.md#installation) to install STUNner.
-
-```console
-helm repo add stunner https://l7mp.io/stunner
-helm repo update
-helm install stunner-gateway-operator stunner/stunner-gateway-operator --create-namespace --namespace stunner-system
-helm install stunner stunner/stunner --namespace stunner
-```
+You will need to install Stunner on Your cluster, you can do this by following the official [installation guide](../../INSTALL.md#installation).
+Wait until all the necessary resources are up and running, then you are ready to continue.
 
 Next, register STUNner with the Kubernetes Gateway API.
 
@@ -94,7 +88,7 @@ Next, register STUNner with the Kubernetes Gateway API.
 kubectl apply -f stunner-gwcc.yaml
 ```
 
-The default configuration uses the `plaintext` STUN/TURN authentication mode with the
+The default configuration uses the `static` STUN/TURN authentication mode with the
 username/password pair `user-1/pass-1`; make sure to [customize](../../AUTH.md) these defaults.
 
 Next, we expose the CloudRetro media services over STUNner.  The below Gateway specification will
@@ -116,7 +110,7 @@ spec:
   listeners:
     - name: udp-listener
       port: 3478
-      protocol: UDP
+      protocol: TURN-UDP
 EOF
 ```
 

--- a/docs/examples/cloudretro/cloudretro-stunner-cleanup.yaml
+++ b/docs/examples/cloudretro/cloudretro-stunner-cleanup.yaml
@@ -9,7 +9,7 @@ spec:
   listeners:
     - name: udp-listener
       port: 3478
-      protocol: UDP
+      protocol: TURN-UDP
 ---
 apiVersion: stunner.l7mp.io/v1
 kind: UDPRoute

--- a/docs/examples/cloudretro/coordinator-config.sh
+++ b/docs/examples/cloudretro/coordinator-config.sh
@@ -24,7 +24,7 @@ done
 
 username=$(kubectl get gatewayconfig -n stunner stunner-gatewayconfig -o jsonpath='{.spec.userName}' --context $secondary_context)
 credential=$(kubectl get gatewayconfig -n stunner stunner-gatewayconfig -o jsonpath='{.spec.password}' --context $secondary_context)
-gwip=$(kubectl get service -n stunner stunner-gateway-udp-gateway-svc -o jsonpath='{.status.loadBalancer.ingress[0].ip}' --context $secondary_context)
+gwip=$(kubectl get service -n stunner udp-gateway -o jsonpath='{.status.loadBalancer.ingress[0].ip}' --context $secondary_context)
 
 kubectl patch configmap -n cloudretro cloudretro-config-c --context $primary_context --patch-file=/dev/stdin <<-EOF
 data:

--- a/docs/examples/cloudretro/stunner-gwcc.yaml
+++ b/docs/examples/cloudretro/stunner-gwcc.yaml
@@ -19,6 +19,6 @@ metadata:
   namespace: stunner
 spec:
   realm: stunner.l7mp.io
-  authType: plaintext
+  authType: static
   userName: "user-1"
   password: "pass-1"

--- a/docs/examples/cloudretro/stunner-setup-for-cloudretro.sh
+++ b/docs/examples/cloudretro/stunner-setup-for-cloudretro.sh
@@ -23,7 +23,7 @@ spec:
   listeners:
     - name: udp-listener
       port: 3478
-      protocol: UDP
+      protocol: TURN-UDP
 EOF
 kubectl apply $context -f - <<EOF
 apiVersion: gateway.networking.k8s.io/v1alpha2


### PR DESCRIPTION
Due to the fact that UDPRoutes aren't followed by their respective services anymore, but having a service for the Gateway itself, this value of the helper-script should have been changed.