### PR TITLE
feat(turncat): Extend help message in `--help`

### DIFF
--- a/cmd/turncat/main.go
+++ b/cmd/turncat/main.go
@@ -43,7 +43,13 @@ func main() {
 	// var passwd = flag.StringP("log", "l", "all:WARN", "Log level (default: all:WARN).")
 	var insecure = flag.BoolP("insecure", "i", false, "Insecure TLS mode, accept self-signed certificates (default: false).")
 	var verbose = flag.BoolP("verbose", "v", false, "Verbose logging, identical to -l all:DEBUG.")
+	var help = flag.BoolP("help", "h", false, "Display this help text and exit")
 	flag.Parse()
+
+	if *help {
+		Usage()
+		os.Exit(0)
+	}
 
 	if flag.NArg() != 3 {
 		Usage()


### PR DESCRIPTION
`turncat -h` output had and extra `pflag: help requested` line. This PR removes it, and provides the extended help message text.

### Output of `./turncat -h`:

#### Before
```
Usage of turncat:
  -i, --insecure     Insecure TLS mode, accept self-signed certificates (default: false).
  -l, --log string   Log level (default: all:WARN). (default "all:WARN")
  -v, --verbose      Verbose logging, identical to -l all:DEBUG.
pflag: help requested
```

#### After
```
turncat [-l|--log <level>] [-i|--insecure] client server peer
        client: <udp|tcp|unix>://<listener_addr>:<listener_port>
        server: <turn://<auth>@<server_addr>:<server_port> | <k8s://<namesspace>/<name>:listener
        peer: udp://<peer_addr>:<peer_port>
        auth: <username:password|secret>
  -h, --help         Display this help text and exit
  -i, --insecure     Insecure TLS mode, accept self-signed certificates (default: false).
  -l, --log string   Log level (default: all:WARN). (default "all:WARN")
  -v, --verbose      Verbose logging, identical to -l all:DEBUG.
```