### PR TITLE
feat: Add `turncat` binaries as release assets

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -92,7 +92,6 @@ jobs:
             os: windows
             file_end: ".exe"
 
-    name: Build release assets
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -65,3 +65,56 @@ jobs:
           repo: stunner-helm
           client_payload: '{"tag": "${{ steps.vars.outputs.tag }}", "type": "stunner"}'
           workflow_file_name: publish.yaml
+
+  add_turncat_binaries:
+    name: Add turncat binaries to release assets
+    needs: run_tests
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - arch: amd64
+            os: linux
+            file_end: ""
+          - arch: arm64
+            os: linux
+            file_end: ""
+          - arch: amd64
+            os: darwin
+            file_end: ""
+          - arch: arm64
+            os: darwin
+            file_end: ""
+          - arch: amd64
+            os: windows
+            file_end: ".exe"
+          - arch: arm64
+            os: windows
+            file_end: ".exe"
+
+    name: Build release assets
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Get version
+        id: vars
+        run: echo tag=$(echo ${GITHUB_REF:11}) >> $GITHUB_OUTPUT
+
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.21'
+
+      - name: Build turncat binary
+        run: |
+          CGO_ENABLED=0 GOARCH=${{ matrix.arch }} GOOS=${{ matrix.os }} go build -ldflags="-w -s" -trimpath -o turncat cmd/turncat/main.go
+          mv turncat turncat-v${{ steps.vars.outputs.tag }}-${{ matrix.os }}-${{ matrix.arch }}${{ matrix.file_end }}
+
+      - name: Release
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: turncat-v${{ steps.vars.outputs.tag }}-${{ matrix.os }}-${{ matrix.arch }}${{ matrix.file_end }}
+          tag: ${{ github.ref_name }}
+          asset_name: turncat-v${{ steps.vars.outputs.tag }}-${{ matrix.os }}-${{ matrix.arch }}${{ matrix.file_end }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -73,23 +73,25 @@ jobs:
     strategy:
       matrix:
         include:
-          - arch: amd64
-            os: linux
+          - os: linux
+            arch: amd64
             file_end: ""
-          - arch: arm64
-            os: linux
+          - os: linux
+            arch: arm64
             file_end: ""
-          - arch: amd64
-            os: darwin
+
+          - os: darwin
+            arch: amd64
             file_end: ""
-          - arch: arm64
-            os: darwin
+          - os: darwin
+            arch: arm64
             file_end: ""
-          - arch: amd64
-            os: windows
+
+          - os: windows
+            arch: amd64
             file_end: ".exe"
-          - arch: arm64
-            os: windows
+          - os: windows
+            arch: arm64
             file_end: ".exe"
 
     steps:


### PR DESCRIPTION
Fixes #114 

test builds are available at https://github.com/levaitamas/stunner/releases/tag/v0.17.0

discord discussion: https://discord.com/channels/945255818494902282/1075804833866596364/threads/1197474904111583242