### PR TITLE
chore(CI/CD): Build and release stunnerctl too & more

### DIFF
--- a/.github/workflows/publish--add-binaries.yml
+++ b/.github/workflows/publish--add-binaries.yml
@@ -1,0 +1,72 @@
+name: "publish: Add binaries to release assets"
+
+on:
+  workflow_call:
+
+jobs:
+  add_binaries:
+    name: Add binaries to release assets
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - os: linux
+            arch: amd64
+            file_end: ""
+          - os: linux
+            arch: arm64
+            file_end: ""
+
+          - os: darwin
+            arch: amd64
+            file_end: ""
+          - os: darwin
+            arch: arm64
+            file_end: ""
+
+          - os: windows
+            arch: amd64
+            file_end: ".exe"
+          - os: windows
+            arch: arm64
+            file_end: ".exe"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Get version
+        id: vars
+        run: echo tag=$(echo ${GITHUB_REF:11}) >> $GITHUB_OUTPUT
+
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.21'
+
+      - name: Build turncat binary
+        run: |
+          CGO_ENABLED=0 GOARCH=${{ matrix.arch }} GOOS=${{ matrix.os }} go build -ldflags="-w -s" -trimpath -o turncat cmd/turncat/main.go
+          mv turncat turncat-v${{ steps.vars.outputs.tag }}-${{ matrix.os }}-${{ matrix.arch }}${{ matrix.file_end }}
+
+      - name: Release turncat binary
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: turncat-v${{ steps.vars.outputs.tag }}-${{ matrix.os }}-${{ matrix.arch }}${{ matrix.file_end }}
+          tag: ${{ github.ref_name }}
+          asset_name: turncat-v${{ steps.vars.outputs.tag }}-${{ matrix.os }}-${{ matrix.arch }}${{ matrix.file_end }}
+
+
+      - name: Build stunnerctl binary
+        run: |
+          CGO_ENABLED=0 GOARCH=${{ matrix.arch }} GOOS=${{ matrix.os }} go build -ldflags="-w -s" -trimpath -o stunnerctl cmd/stunnerctl/main.go
+          mv stunnerctl stunnerctl-v${{ steps.vars.outputs.tag }}-${{ matrix.os }}-${{ matrix.arch }}${{ matrix.file_end }}
+
+      - name: Release stunnerctl binary
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: stunnerctl-v${{ steps.vars.outputs.tag }}-${{ matrix.os }}-${{ matrix.arch }}${{ matrix.file_end }}
+          tag: ${{ github.ref_name }}
+          asset_name: stunnerctl-v${{ steps.vars.outputs.tag }}-${{ matrix.os }}-${{ matrix.arch }}${{ matrix.file_end }}

--- a/.github/workflows/publish--push-charts.yml
+++ b/.github/workflows/publish--push-charts.yml
@@ -1,0 +1,40 @@
+name: "publish: Push Helm charts to web"
+
+on:
+  workflow_call:
+    with:
+      inputs:
+        dev:
+          description: Whether to release a dev version
+          required: true
+          type: boolean
+
+jobs:
+  push_charts:
+    name: Push Helm charts to web
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get version for non-dev release
+        if: ${{ inputs.dev == false || inputs.dev == 'false' }}
+        id: vars
+        run: echo tag=$(echo ${GITHUB_REF:11}) >> $GITHUB_OUTPUT
+
+      - name: Trigger release workflow in the stunner-helm repo
+        if: ${{ inputs.dev == false || inputs.dev == 'false' }}
+        uses: convictional/trigger-workflow-and-wait@v1.6.5
+        with:
+          github_token: ${{ secrets.WEB_PAT_TOKEN }}
+          owner: l7mp
+          repo: stunner-helm
+          client_payload: '{"tag": "${{ steps.vars.outputs.tag }}", "type": "stunner"}'
+          workflow_file_name: publish.yaml
+
+      - name: Trigger release workflow in the stunner-helm repo
+        if: ${{ inputs.dev == true || inputs.dev == 'true' }}
+        uses: convictional/trigger-workflow-and-wait@v1.6.5
+        with:
+          github_token: ${{ secrets.WEB_PAT_TOKEN }}
+          owner: l7mp
+          repo: stunner-helm
+          client_payload: '{"tag": "dev", "type": "stunner"}'
+          workflow_file_name: publish.yaml

--- a/.github/workflows/publish-dev.yaml
+++ b/.github/workflows/publish-dev.yaml
@@ -56,13 +56,6 @@ jobs:
   push_chart:
     name: Push helm charts to the repo
     needs: push_to_registry
-    runs-on: ubuntu-latest
-    steps:
-      - name: Triggering release workflow in the stunner-helm repo
-        uses: convictional/trigger-workflow-and-wait@v1.6.5
-        with:
-          github_token: ${{ secrets.WEB_PAT_TOKEN }}
-          owner: l7mp
-          repo: stunner-helm
-          client_payload: '{"tag": "dev", "type": "stunner"}'
-          workflow_file_name: publish.yaml
+    uses: l7mp/stunner/.github/workflows/publish--push-charts.yml@main
+    with:
+      dev: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -66,56 +66,7 @@ jobs:
           client_payload: '{"tag": "${{ steps.vars.outputs.tag }}", "type": "stunner"}'
           workflow_file_name: publish.yaml
 
-  add_turncat_binaries:
-    name: Add turncat binaries to release assets
+  add_binaries:
+    name: Add binaries to release assets
+    uses: l7mp/stunner/.github/workflows/publish--add-binaries.yml@main
     needs: run_tests
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        include:
-          - os: linux
-            arch: amd64
-            file_end: ""
-          - os: linux
-            arch: arm64
-            file_end: ""
-
-          - os: darwin
-            arch: amd64
-            file_end: ""
-          - os: darwin
-            arch: arm64
-            file_end: ""
-
-          - os: windows
-            arch: amd64
-            file_end: ".exe"
-          - os: windows
-            arch: arm64
-            file_end: ".exe"
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Get version
-        id: vars
-        run: echo tag=$(echo ${GITHUB_REF:11}) >> $GITHUB_OUTPUT
-
-      - name: Install Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: '1.21'
-
-      - name: Build turncat binary
-        run: |
-          CGO_ENABLED=0 GOARCH=${{ matrix.arch }} GOOS=${{ matrix.os }} go build -ldflags="-w -s" -trimpath -o turncat cmd/turncat/main.go
-          mv turncat turncat-v${{ steps.vars.outputs.tag }}-${{ matrix.os }}-${{ matrix.arch }}${{ matrix.file_end }}
-
-      - name: Release
-        uses: svenstaro/upload-release-action@v2
-        with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: turncat-v${{ steps.vars.outputs.tag }}-${{ matrix.os }}-${{ matrix.arch }}${{ matrix.file_end }}
-          tag: ${{ github.ref_name }}
-          asset_name: turncat-v${{ steps.vars.outputs.tag }}-${{ matrix.os }}-${{ matrix.arch }}${{ matrix.file_end }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,22 +49,11 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
 
   push_chart:
-    name: Push charts to the web
+    name: Push helm charts to the repo
     needs: push_to_registry
-    runs-on: ubuntu-latest
-    steps:
-      - name: Get version
-        id: vars
-        run: echo tag=$(echo ${GITHUB_REF:11}) >> $GITHUB_OUTPUT
-
-      - name: Triggering release workflow in the stunner-helm repo
-        uses: convictional/trigger-workflow-and-wait@v1.6.5
-        with:
-          github_token: ${{ secrets.WEB_PAT_TOKEN }}
-          owner: l7mp
-          repo: stunner-helm
-          client_payload: '{"tag": "${{ steps.vars.outputs.tag }}", "type": "stunner"}'
-          workflow_file_name: publish.yaml
+    uses: l7mp/stunner/.github/workflows/publish--push-charts.yml@main
+    with:
+      dev: false
 
   add_binaries:
     name: Add binaries to release assets

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Convert coverage.out to coverage.lcov
         uses: jandelgado/gcov2lcov-action@v1
       - name: Coveralls
-        uses: coverallsapp/github-action@v1
+        uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.github_token }}
           path-to-lcov: coverage.lcov


### PR DESCRIPTION
- build and release `turncat` and `stunnerctl` binaries on release
- fix node.js version warning in test action
- introduce reusable workflow for pushing helm charts (TODO: refactor docker push too)