### PR TITLE
Monitoring: Add stunner_allocations_active in the doc

### DIFF
--- a/docs/MONITORING.md
+++ b/docs/MONITORING.md
@@ -30,7 +30,8 @@ STUNner provides deep visibility into the amount of traffic sent and received on
 
 | Metric | Description | Type | Labels |
 | :--- | :--- | :--- | :--- |
-| `stunner_listener_connections` | Number of *active* downstream connections at a listener. | gauge | `name=<listener-name>` |
+| `stunner_allocations_active` | Number of active allocations. | gauge | none |
+| `stunner_listener_connections` | Number of *active* downstream connections at a listener. Stays constant when using only UDP listeners. | gauge | `name=<listener-name>` |
 | `stunner_listener_connections_total` | Number of downstream connections at a listener. | counter | `name=<listener-name>` |
 | `stunner_listener_packets_total` | Number of datagrams sent or received at a listener. Unreliable for listeners running on a connection-oriented transport protocol (TCP/TLS).  | counter | `direction=<rx\|tx>`, `name=<listener-name>`|
 | `stunner_listener_bytes_total` | Number of bytes sent or received at a listener. | counter | `direction=<rx\|tx>`, `name=<listener-name>` |


### PR DESCRIPTION
Hello!

This PR proposes updating the monitoring documentation to follow the changes introduced in the PR https://github.com/l7mp/stunner/pull/140, which enabled the `stunner_allocations_active` metric.