### PR TITLE
feat(icetester): Create GW for chosen proto only

### DIFF
--- a/internal/icetester/icetester.go
+++ b/internal/icetester/icetester.go
@@ -262,7 +262,7 @@ func (t *iceTester) Start(ctx context.Context) error {
 	}
 
 	log.Infof("Inserting tester artifacts")
-	for _, obj := range newICETesterICETesterResources(t.namespace, t.iceTesterImage) {
+	for _, obj := range newICETesterICETesterResources(t.namespace, t.iceTesterImage, t.transports) {
 		if err := t.safelyRemove(ctx, obj, metav1.GetOptions{}, metav1.DeleteOptions{}); err != nil {
 			return t.sendEventComplete(EventInstallationComplete,
 				fmt.Errorf("Failed to clean up resource %s/%s of kind %s: %w",
@@ -285,7 +285,7 @@ func (t *iceTester) Start(ctx context.Context) error {
 			obj.GetName(), obj.GetKind())
 	}
 	defer func() {
-		for _, obj := range newICETesterICETesterResources(t.namespace, t.iceTesterImage) {
+		for _, obj := range newICETesterICETesterResources(t.namespace, t.iceTesterImage, t.transports) {
 			// do not use ctx: it might have timed out
 			if err := t.delete(context.TODO(), obj, metav1.DeleteOptions{}); err != nil {
 				log.Errorf("Error deleting resource: %s", err.Error())

--- a/internal/icetester/utils.go
+++ b/internal/icetester/utils.go
@@ -54,7 +54,7 @@ func gwFromProto(proto v1.ListenerProtocol, ns string) *unstructured.Unstructure
 	}
 }
 
-// updateICEServerAddr modifies the cluster-side ICE server config for symmetric ICe tests so that
+// updateICEServerAddr modifies the cluster-side ICE server config for symmetric ICE tests so that
 // the backend will be configured with the gateway as a TURN server
 func (t *iceTester) updateICEServerAddr(ss []webrtc.ICEServer, proto v1.ListenerProtocol) []webrtc.ICEServer {
 	// use service as the TURN server address


### PR DESCRIPTION
This PR limits `icetester` to create gateway for selected protocols only.

### Note

⚠️ This change somehow breaks the symmetric `tcp` test:  
```console
bin/stunnerctl icetest tcp -l all:INFO --force-cleanup --offload-mode=None
26 May 25 13:39 CEST: Initializing... completed
26 May 25 13:39 CEST: Checking installation... completed
26 May 25 13:39 CEST: Checking Gateway... completed
26 May 25 13:39 CEST: Obtaining ICE server configuration... completed
26 May 25 13:39 CEST: Running asymmetric ICE test over TURN-TCP... completed
        Statistics: rate=48.45pps, loss=0/969pkts=0.00%, RTT:mean=1.01ms/median=0.99ms/P95=1.15ms/P99=1.39ms
        LocalICECandidates:
          * udp4 relay 10.42.0.147:41305 related 1xx.xxx.xxx.xxx:38422 (resolved: 10.42.0.147:41305)
        RemoteICECandidates:
          * udp4 host 10.42.0.148:50965 (resolved: 10.42.0.148:50965)
26 May 25 13:40 CEST: Running symmetric ICE test over TURN-TCP... error
Error: "Could not send WHIP request to ICE tester backend: context deadline exceeded"
TimeStamp: 2025-05-26 13:41:56
Diagnostics: The ICE test has failed. Check the reported error!
Detailed logs
13:39:27.652603 icetester.go:158: icetester INFO: Creating a Kubernetes client
[...]
```

Testing with `tcp` and `udp` still works:
```console
bin/stunnerctl icetest udp tcp -l all:INFO --force-cleanup --offload-mode=None
26 May 25 13:43 CEST: Initializing... completed
26 May 25 13:43 CEST: Checking installation... completed
26 May 25 13:44 CEST: Checking Gateway... completed
26 May 25 13:44 CEST: Obtaining ICE server configuration... completed
26 May 25 13:44 CEST: Running asymmetric ICE test over TURN-UDP... completed
        Statistics: rate=48.65pps, loss=0/973pkts=0.00%, RTT:mean=0.96ms/median=0.95ms/P95=1.09ms/P99=1.17ms
        LocalICECandidates:
          * udp4 relay 10.42.0.150:58810 related 0.0.0.0:48216 (resolved: 10.42.0.150:58810)
        RemoteICECandidates:
          * udp4 host 10.42.0.153:32895 (resolved: 10.42.0.153:32895)
26 May 25 13:44 CEST: Running asymmetric ICE test over TURN-TCP... completed
        Statistics: rate=48.35pps, loss=0/967pkts=0.00%, RTT:mean=1.01ms/median=0.99ms/P95=1.12ms/P99=1.24ms
        LocalICECandidates:
          * udp4 relay 10.42.0.152:49818 related 1xx.xxx.xxx.xxx:48628 (resolved: 10.42.0.152:49818)
        RemoteICECandidates:
          * udp4 host 10.42.0.153:42399 (resolved: 10.42.0.153:42399)
26 May 25 13:44 CEST: Running symmetric ICE test over TURN-UDP... completed
        Statistics: rate=48.80pps, loss=0/976pkts=0.00%, RTT:mean=1.10ms/median=1.07ms/P95=1.24ms/P99=1.49ms
        LocalICECandidates:
          * udp4 relay 10.42.0.150:46996 related 0.0.0.0:46296 (resolved: 10.42.0.150:46996)
        RemoteICECandidates:
          * udp4 relay 10.42.0.150:43766 related 0.0.0.0:40102 (resolved: 10.42.0.150:43766)
26 May 25 13:45 CEST: Running symmetric ICE test over TURN-TCP... completed
        Statistics: rate=49.25pps, loss=0/985pkts=0.00%, RTT:mean=1.21ms/median=1.20ms/P95=1.35ms/P99=1.46ms
        LocalICECandidates:
          * udp4 relay 10.42.0.152:34323 related 1xx.xxx.xxx.xxx:59126 (resolved: 10.42.0.152:34323)
        RemoteICECandidates:
          * udp4 relay 10.42.0.152:48566 related 10.42.0.153:43538 (resolved: 10.42.0.152:48566)
```