### PR TITLE
fix(server,relay): bind dualstack wildcard for IPv6-only clusters

### DIFF
--- a/relay.go
+++ b/relay.go
@@ -65,7 +65,12 @@ func NewRelayGen(l *object.Listener, t *telemetry.Telemetry, logger logger.Logge
 	return &RelayGen{
 		Listener:     l,
 		RelayAddress: l.Addr,
-		Address:      "0.0.0.0",
+		// Empty string is IPADDR_ANY: on dual-stack hosts (Linux default with
+		// net.ipv6.bindv6only=0) ListenPacket("udp", ":0") binds a single
+		// socket reachable from both IPv4 and IPv6 peers. Earlier releases
+		// hardcoded "0.0.0.0" here, which silently broke relays to IPv6-only
+		// peers (e.g. IPv6-only EKS pods).
+		Address:      "",
 		ClusterCache: lru.New(ClusterCacheSize),
 		Net:          l.Net,
 		Logger:       logger,

--- a/server.go
+++ b/server.go
@@ -37,7 +37,14 @@ func (s *Stunner) StartServer(l *object.Listener) error {
 
 	permissionHandler := s.NewPermissionHandler(l)
 
-	addr := fmt.Sprintf("0.0.0.0:%d", l.Port)
+	// Wildcard bind: ":port" parses as the unspecified address. On dual-stack
+	// hosts (Linux default with net.ipv6.bindv6only=0) this gives a single
+	// socket reachable via both IPv4 and IPv6; on IPv4-only or IPv6-only
+	// hosts it still binds the available family. Earlier releases hardcoded
+	// "0.0.0.0:%d" together with the IPv4-only network "udp4" (and "udp4"
+	// for DTLS), which silently failed on IPv6-only clusters (e.g. IPv6-only
+	// EKS).
+	addr := fmt.Sprintf(":%d", l.Port)
 
 	switch l.Proto {
 	case stnrv1.ListenerProtocolTURNUDP:
@@ -45,7 +52,7 @@ func (s *Stunner) StartServer(l *object.Listener) error {
 
 		s.log.Infof("setting up UDP listener socket pool at %s with %d readloop threads",
 			addr, socketPool.Size())
-		conns, err := socketPool.ListenPacket("udp4", addr)
+		conns, err := socketPool.ListenPacket("udp", addr)
 		if err != nil {
 			return err
 		}
@@ -118,11 +125,11 @@ func (s *Stunner) StartServer(l *object.Listener) error {
 		}
 
 		// for some reason dtls.Listen requires a UDPAddr and not an addr string
-		udpAddr, err := net.ResolveUDPAddr("udp4", addr)
+		udpAddr, err := net.ResolveUDPAddr("udp", addr)
 		if err != nil {
 			return fmt.Errorf("failed to parse DTLS listener address %s: %s", addr, err)
 		}
-		dtlsListener, err := dtls.ListenWithOptions("udp4", udpAddr,
+		dtlsListener, err := dtls.ListenWithOptions("udp", udpAddr,
 			dtls.WithCertificates(cer),
 		)
 		if err != nil {


### PR DESCRIPTION
## Summary

`StartServer` and `NewRelayGen` hardcoded `0.0.0.0` together with the
IPv4-only network strings `udp4`/`tcp4` (in DTLS as well). On IPv4-only
hosts this is fine, but on IPv6-only hosts the listener and relay
sockets cannot be reached at all and TURN allocations silently fail
with no obvious log line.

This change switches both call sites to the unspecified-address /
family-neutral network strings:

- `server.go` — listener bind: `"0.0.0.0:%d"` → `":%d"`,
  `socketPool.ListenPacket("udp4", ...)` → `"udp"`,
  `net.ResolveUDPAddr("udp4", ...)` and `dtls.ListenWithOptions("udp4", ...)`
  → `"udp"`. The TCP/TLS branches were already family-neutral, so they
  just inherit the new `:port` form.
- `relay.go` — `RelayGen.Address` default: `"0.0.0.0"` → `""`. The
  comment at `AllocatePacketConn` already noted that an empty address is
  the only correct value when the requested network can be either v4 or
  v6 — this just makes the default match that comment.

On Linux with the default `net.ipv6.bindv6only=0`, this opens a single
IPv6 wildcard socket that accepts both IPv4 (mapped) and IPv6 peers; on
IPv4-only or IPv6-only hosts it still binds the available family. Net
result: IPv4-only deployments are unaffected, IPv6-only deployments
start working, and dual-stack deployments now actually carry both
families instead of silently dropping IPv6 traffic.

## Verification

Verified end-to-end on an IPv6-only Linux host with a custom build of
stunnerd from this branch:

- Before: all 16 UDP socket-pool sockets bound on `0.0.0.0:<port>`,
  `/proc/net/udp6` empty, TURN allocate from an IPv6-only client times
  out (no allocate response).
- After: all 16 sockets bound on `[::]:<port>` (IPv6 wildcard,
  dual-stack via `bindv6only=0`), `/proc/net/udp` empty, TURN allocate
  from an IPv6-only client succeeds — `coturn turnutils_uclient`
  receives an `Allocate Success` and a relay address on the listener's
  IPv6 prefix.

Illustrative `turnutils_uclient` output (addresses elided / replaced
with documentation-prefix examples):

```text
0: INFO: IPv6. Connected from: <client-ipv6>:<ephemeral>
0: INFO: IPv6. Connected to:   <listener-ipv6>:<turn-port>
0: INFO: allocate sent
0: INFO: allocate response received:
0: INFO: success
0: INFO: IPv6. Received relay addr: <relay-ipv6>:<relay-port>
```

Smoke-tested in a dual-stack environment with no regression.

## Test plan

- [ ] CI green on `main`
- [ ] `make test` locally
- [ ] Manual sanity on a dual-stack host (no behavior change)
- [ ] Manual sanity on an IPv4-only host (no behavior change)
- [x] Manual verification on an IPv6-only host (TURN allocate now
      succeeds, was previously silently broken)