### PR TITLE
fix(relay): force dual-stack relay socket for wildcard listeners

### DIFF
--- a/relay.go
+++ b/relay.go
@@ -65,7 +65,12 @@ func NewRelayGen(l *object.Listener, t *telemetry.Telemetry, logger logger.Logge
 	return &RelayGen{
 		Listener:     l,
 		RelayAddress: l.Addr,
-		Address:      "0.0.0.0",
+		// Empty string is IPADDR_ANY: on dual-stack hosts (Linux default with
+		// net.ipv6.bindv6only=0) ListenPacket("udp", ":0") binds a single
+		// socket reachable from both IPv4 and IPv6 peers. Earlier releases
+		// hardcoded "0.0.0.0" here, which silently broke relays to IPv6-only
+		// peers (e.g. IPv6-only EKS pods).
+		Address:      "",
 		ClusterCache: lru.New(ClusterCacheSize),
 		Net:          l.Net,
 		Logger:       logger,

--- a/relay.go
+++ b/relay.go
@@ -91,9 +91,27 @@ func (r *RelayGen) AllocatePacketConn(conf turn.AllocateListenerConfig) (net.Pac
 		requestedPort = 0
 	}
 
-	// This will fail unless (1) r.Address is "" (IPADDR_ANY), or (2) r.Address is IPv4 and the
-	// requested network is also IPv4, or (3) both are IPv6.
-	conn, err := r.Net.ListenPacket(conf.Network, fmt.Sprintf("%s:%d", r.Address, requestedPort))
+	// pion/turn passes a family-pinned Network ("udp4" or "udp6") derived
+	// from the allocation's RFC 6156 family. On Linux dual-stack hosts that
+	// hint forces ListenPacket into a single-family socket regardless of how
+	// the listener itself was bound -- so a relay allocated from an IPv6-only
+	// Kubernetes cluster (where pion/turn defaults to the RFC 6156 IPv4
+	// family because the Allocate request omits REQUESTED-ADDRESS-FAMILY) is
+	// unreachable for the cluster's IPv6 backend pods.
+	//
+	// When the listener Address is the wildcard, override the network with
+	// the family-neutral "udp" so a single relay socket binds [::] and
+	// reaches both IPv4 and IPv6 peers. Pinned Address listeners are
+	// untouched and keep RFC 6156 strict family behavior.
+	//
+	// End-to-end cross-family forwarding additionally requires pion/turn's
+	// permission family check to accept v6 peers on a v4 allocation; see the
+	// pion/turn upstream issue tracking that.
+	network := conf.Network
+	if r.Address == "" && (network == "udp4" || network == "udp6") {
+		network = "udp"
+	}
+	conn, err := r.Net.ListenPacket(network, fmt.Sprintf("%s:%d", r.Address, requestedPort))
 	if err != nil {
 		return nil, nil, err
 	}

--- a/server.go
+++ b/server.go
@@ -37,7 +37,14 @@ func (s *Stunner) StartServer(l *object.Listener) error {
 
 	permissionHandler := s.NewPermissionHandler(l)
 
-	addr := fmt.Sprintf("0.0.0.0:%d", l.Port)
+	// Wildcard bind: ":port" parses as the unspecified address. On dual-stack
+	// hosts (Linux default with net.ipv6.bindv6only=0) this gives a single
+	// socket reachable via both IPv4 and IPv6; on IPv4-only or IPv6-only
+	// hosts it still binds the available family. Earlier releases hardcoded
+	// "0.0.0.0:%d" together with the IPv4-only network "udp4" (and "udp4"
+	// for DTLS), which silently failed on IPv6-only clusters (e.g. IPv6-only
+	// EKS).
+	addr := fmt.Sprintf(":%d", l.Port)
 
 	switch l.Proto {
 	case stnrv1.ListenerProtocolTURNUDP:
@@ -45,7 +52,7 @@ func (s *Stunner) StartServer(l *object.Listener) error {
 
 		s.log.Infof("setting up UDP listener socket pool at %s with %d readloop threads",
 			addr, socketPool.Size())
-		conns, err := socketPool.ListenPacket("udp4", addr)
+		conns, err := socketPool.ListenPacket("udp", addr)
 		if err != nil {
 			return err
 		}
@@ -118,11 +125,11 @@ func (s *Stunner) StartServer(l *object.Listener) error {
 		}
 
 		// for some reason dtls.Listen requires a UDPAddr and not an addr string
-		udpAddr, err := net.ResolveUDPAddr("udp4", addr)
+		udpAddr, err := net.ResolveUDPAddr("udp", addr)
 		if err != nil {
 			return fmt.Errorf("failed to parse DTLS listener address %s: %s", addr, err)
 		}
-		dtlsListener, err := dtls.ListenWithOptions("udp4", udpAddr,
+		dtlsListener, err := dtls.ListenWithOptions("udp", udpAddr,
 			dtls.WithCertificates(cer),
 		)
 		if err != nil {


### PR DESCRIPTION
## What

Override pion/turn's family-pinned `AllocateListenerConfig.Network` hint
(`udp4` / `udp6`) with the family-neutral `udp` when the listener uses
the wildcard `Address`, so the relay socket binds `[::]` on Linux
dual-stack hosts and reaches both IPv4 and IPv6 peers from a single
allocation.

A no-op when `r.Address` is family-pinned (RFC 6156 strict behavior is
preserved).

## Why

Browsers' TURN clients omit `REQUESTED-ADDRESS-FAMILY` in their
`Allocate` request, so pion/turn falls back to the RFC 6156 default IPv4
family. The Allocation Manager then asks the relay generator to listen
on `udp4`. On an IPv6-only Kubernetes cluster, a pion-based WebRTC
media-server pod only has an IPv6 address, so a single-family IPv4
relay socket can never reach it.

The result is what looks like a successful TURN allocation with no
working media path: `Allocate` succeeds, `CreatePermission` for an
IPv6 peer is silently dropped by pion/turn's strict `ipMatchesFamily`,
`Send-indication` fails with "no permission added", and the WebRTC
peer-connection times out.

## Stack

This builds on #225 (`Address: "0.0.0.0"` → `""`). Together they make
the listener and relay sockets uniformly dual-stack on dual-stack hosts.

## Pairing pion/turn fix

End-to-end cross-family forwarding additionally requires pion/turn's
`internal/server/turn.go` to accept IPv6 peers on a default-IPv4
allocation (`ipMatchesFamily`). Tracked at **pion/turn#566** and
proposed in **pion/turn#567**. Until that lands, deployments need a
vendored pion/turn (a `replace` directive in `go.mod` is enough).

## Verified

On an IPv6-only Linux host with a custom build of stunnerd from this
branch:

- Listener socket-pool bound on `[::]:<turn-port>` (verified via
  `/proc/net/udp6`).
- Relay socket bound on `[::]:<random>` after Allocate (was previously
  IPv4-only).
- Pure IPv6 backend pod reachable through TURN end-to-end with the
  paired pion/turn patch above; ICE candidate pairs forced to relay
  (`iceTransportPolicy: "relay"`) succeed, browser reports media
  flowing through the relay candidate.

No regression on dual-stack and IPv4-only hosts.

Refs: #225, pion/turn#566, pion/turn#567