### PR TITLE
Pin unpinned-action references across 8 workflows

### DIFF
--- a/.github/workflows/e2e-test-dev.yaml
+++ b/.github/workflows/e2e-test-dev.yaml
@@ -9,10 +9,10 @@ jobs:
   e2e_test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
         with:
           go-version: '1.26'
 
@@ -24,7 +24,7 @@ jobs:
         run: CGO_ENABLED=0 go build -ldflags="-w -s" -o turncat cmd/turncat/main.go
 
       - name: Start minikube
-        uses: medyagh/setup-minikube@master
+        uses: medyagh/setup-minikube@e54c6bfce85fe75714fc113f1fa200c23338732b
         with:
           driver: docker
           container-runtime: containerd
@@ -36,7 +36,7 @@ jobs:
         run: minikube tunnel &>mktunnel.log &
 
       - name: Set up Helm
-        uses: azure/setup-helm@v5
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2
         with:
           version: v3.16.2
 

--- a/.github/workflows/e2e-test-stable.yml
+++ b/.github/workflows/e2e-test-stable.yml
@@ -9,7 +9,7 @@ jobs:
   e2e_test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
 
       - name: Install turncat
         run: |
@@ -18,7 +18,7 @@ jobs:
           chmod a+x turncat
 
       - name: Start minikube
-        uses: medyagh/setup-minikube@master
+        uses: medyagh/setup-minikube@e54c6bfce85fe75714fc113f1fa200c23338732b
         with:
           driver: docker
           container-runtime: containerd
@@ -29,7 +29,7 @@ jobs:
         run: minikube tunnel &>mktunnel.log &
 
       - name: Set up Helm
-        uses: azure/setup-helm@v5
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2
         with:
           version: v3.16.2
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,12 +19,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
 
       - name: Install Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
         with:
           go-version: '1.26'
 
       - name: Run linters
-        uses: golangci/golangci-lint-action@v9
+        uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee

--- a/.github/workflows/publish--add-binaries.yml
+++ b/.github/workflows/publish--add-binaries.yml
@@ -33,14 +33,14 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
 
       - name: Get version
         id: vars
         run: echo tag=$(echo ${GITHUB_REF:11}) >> $GITHUB_OUTPUT
 
       - name: Install Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
         with:
           go-version: '1.26'
 
@@ -52,7 +52,7 @@ jobs:
           mv bin/stunnerctl stunnerctl-v${{ steps.vars.outputs.tag }}-${{ matrix.os }}-${{ matrix.arch }}${{ matrix.file_end }}
 
       - name: Release turncat binary
-        uses: svenstaro/upload-release-action@v2
+        uses: svenstaro/upload-release-action@29e53e917877a24fad85510ded594ab3c9ca12de
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: turncat-v${{ steps.vars.outputs.tag }}-${{ matrix.os }}-${{ matrix.arch }}${{ matrix.file_end }}
@@ -60,7 +60,7 @@ jobs:
           asset_name: turncat-v${{ steps.vars.outputs.tag }}-${{ matrix.os }}-${{ matrix.arch }}${{ matrix.file_end }}
 
       - name: Release stunnerctl binary
-        uses: svenstaro/upload-release-action@v2
+        uses: svenstaro/upload-release-action@29e53e917877a24fad85510ded594ab3c9ca12de
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: stunnerctl-v${{ steps.vars.outputs.tag }}-${{ matrix.os }}-${{ matrix.arch }}${{ matrix.file_end }}

--- a/.github/workflows/publish--push-charts.yml
+++ b/.github/workflows/publish--push-charts.yml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Trigger release workflow in the stunner-helm repo
         if: ${{ inputs.dev == false || inputs.dev == 'false' }}
-        uses: benc-uk/workflow-dispatch@v1
+        uses: benc-uk/workflow-dispatch@31e2b3319479a63f0ab15bf800eff9e913504e26
         with:
           token: ${{ secrets.WEB_PAT_TOKEN }}
           repo: l7mp/stunner-helm
@@ -29,7 +29,7 @@ jobs:
 
       - name: Trigger release workflow in the stunner-helm repo
         if: ${{ inputs.dev == true || inputs.dev == 'true' }}
-        uses: benc-uk/workflow-dispatch@v1
+        uses: benc-uk/workflow-dispatch@31e2b3319479a63f0ab15bf800eff9e913504e26
         with:
           token: ${{ secrets.WEB_PAT_TOKEN }}
           repo: l7mp/stunner-helm

--- a/.github/workflows/publish-dev.yaml
+++ b/.github/workflows/publish-dev.yaml
@@ -23,30 +23,30 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9
         with:
           images: l7mp/stunnerd
           tags: |
             type=raw,value=dev
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee
         with:
           username: ${{ secrets.DOCKER_USER }}
           password: ${{ secrets.DOCKER_TOKEN }}
 
       - name: Build and Push
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf
         with:
           context: .
           platforms: linux/amd64,linux/arm64
@@ -70,30 +70,30 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9
         with:
           images: l7mp/icetester
           tags: |
             type=raw,value=dev
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee
         with:
           username: ${{ secrets.DOCKER_USER }}
           password: ${{ secrets.DOCKER_TOKEN }}
 
       - name: Build and Push
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf
         with:
           file: Dockerfile.icetester
           context: .

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
 
       - name: Verify README is release-ready
         run: |
@@ -35,11 +35,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9
         with:
           images: l7mp/stunnerd
           tags: |
@@ -47,19 +47,19 @@ jobs:
             type=raw,value=latest
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee
         with:
           username: ${{ secrets.DOCKER_USER }}
           password: ${{ secrets.DOCKER_TOKEN }}
 
       - name: Build and Push
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf
         with:
           context: .
           platforms: linux/amd64,linux/arm64
@@ -82,11 +82,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9
         with:
           images: l7mp/icetester
           tags: |
@@ -94,19 +94,19 @@ jobs:
             type=raw,value=latest
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee
         with:
           username: ${{ secrets.DOCKER_USER }}
           password: ${{ secrets.DOCKER_TOKEN }}
 
       - name: Build and Push
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf
         with:
           file: Dockerfile.icetester
           context: .

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,9 +19,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
         with:
           go-version: '1.26'
       - name: Download modules
@@ -31,7 +31,7 @@ jobs:
       - name: Test
         run: go test -v -covermode=count -coverprofile=coverage.out
       - name: Coveralls
-        uses: coverallsapp/github-action@v2
+        uses: coverallsapp/github-action@5cbfd81b66ca5d10c19b062c04de0199c215fb6e
         if: github.repository == 'l7mp/stunner'
         with:
           github-token: ${{ secrets.github_token }}
@@ -42,9 +42,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [test]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
       - name: Check security vulnerabilites
-        uses: anchore/scan-action@v7
+        uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2
         with:
           path: "."
           fail-build: true


### PR DESCRIPTION
> 🤖 An AI-generated pull request from [codeopsai](https://codeopsai.com). We open PRs only when we find a concrete, citable issue worth fixing. Not useful? Comment **"no thanks"** and we won't open more.

<details>
<summary>About codeopsai</summary>

codeopsai analyzes public GitHub Actions workflows for security and reliability issues and opens fixes for maintainer review. Every PR carries citations to the relevant standard (CWE, GitHub docs) and a structural verification trail; if our evidence bar isn't met, we don't open the PR.

**Mistake, or unwelcome?** Comment here or open an issue at [github.com/codeopsai/feedback](https://github.com/codeopsai/feedback). We read every one and adjust.
</details>

## Why these matter

**Why pin to a SHA** (`unpinned-action`)

Each unpinned action reference can be force-moved to attacker-controlled code by the action's owner or anyone who compromises their account — exactly what happened in the tj-actions/changed-files attack (CVE-2025-30066, Mar 2025). Pinning to a 40-character commit SHA freezes the exact reviewed code.

Reference: CWE-829 · [GitHub/OWASP guidance](https://docs.github.com/en/actions/reference/security/secure-use) · Real-world precedent: tj-actions/changed-files supply-chain attack (CVE-2025-30066, Mar 2025)

### `.github/workflows/e2e-test-dev.yaml`

- 🟠 MED `medyagh/setup-minikube` (job `e2e_test`)
- 🟠 MED `azure/setup-helm` (job `e2e_test`)
- ⚪ LOW `actions/checkout` (job `e2e_test`)
- ⚪ LOW `actions/setup-go` (job `e2e_test`)

<details>
<summary>Diff</summary>

```diff
--- a/.github/workflows/e2e-test-dev.yaml
+++ b/.github/workflows/e2e-test-dev.yaml
@@ -9,10 +9,10 @@
   e2e_test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
         with:
           go-version: '1.26'
 
@@ -24,7 +24,7 @@
         run: CGO_ENABLED=0 go build -ldflags="-w -s" -o turncat cmd/turncat/main.go
 
       - name: Start minikube
-        uses: medyagh/setup-minikube@master
+        uses: medyagh/setup-minikube@e54c6bfce85fe75714fc113f1fa200c23338732b
         with:
           driver: docker
           container-runtime: containerd
@@ -36,7 +36,7 @@
         run: minikube tunnel &>mktunnel.log &
 
       - name: Set up Helm
-        uses: azure/setup-helm@v5
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2
         with:
           version: v3.16.2
 
```

</details>

### `.github/workflows/e2e-test-stable.yml`

- 🟠 MED `medyagh/setup-minikube` (job `e2e_test`)
- 🟠 MED `azure/setup-helm` (job `e2e_test`)
- ⚪ LOW `actions/checkout` (job `e2e_test`)

<details>
<summary>Diff</summary>

```diff
--- a/.github/workflows/e2e-test-stable.yml
+++ b/.github/workflows/e2e-test-stable.yml
@@ -9,7 +9,7 @@
   e2e_test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
 
       - name: Install turncat
         run: |
@@ -18,7 +18,7 @@
           chmod a+x turncat
 
       - name: Start minikube
-        uses: medyagh/setup-minikube@master
+        uses: medyagh/setup-minikube@e54c6bfce85fe75714fc113f1fa200c23338732b
         with:
           driver: docker
           container-runtime: containerd
@@ -29,7 +29,7 @@
         run: minikube tunnel &>mktunnel.log &
 
       - name: Set up Helm
-        uses: azure/setup-helm@v5
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2
         with:
           version: v3.16.2
 
```

</details>

### `.github/workflows/lint.yml`

- 🟠 MED `golangci/golangci-lint-action` (job `lint`)
- ⚪ LOW `actions/checkout` (job `lint`)
- ⚪ LOW `actions/setup-go` (job `lint`)

<details>
<summary>Diff</summary>

```diff
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,12 +19,12 @@
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
 
       - name: Install Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
         with:
           go-version: '1.26'
 
       - name: Run linters
-        uses: golangci/golangci-lint-action@v9
+        uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee
```

</details>

### `.github/workflows/publish--add-binaries.yml`

- 🟠 MED `svenstaro/upload-release-action` (job `add_binaries`)
- 🟠 MED `svenstaro/upload-release-action` (job `add_binaries`)
- ⚪ LOW `actions/checkout` (job `add_binaries`)
- ⚪ LOW `actions/setup-go` (job `add_binaries`)

<details>
<summary>Diff</summary>

```diff
--- a/.github/workflows/publish--add-binaries.yml
+++ b/.github/workflows/publish--add-binaries.yml
@@ -33,14 +33,14 @@
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
 
       - name: Get version
         id: vars
         run: echo tag=$(echo ${GITHUB_REF:11}) >> $GITHUB_OUTPUT
 
       - name: Install Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
         with:
           go-version: '1.26'
 
@@ -52,7 +52,7 @@
           mv bin/stunnerctl stunnerctl-v${{ steps.vars.outputs.tag }}-${{ matrix.os }}-${{ matrix.arch }}${{ matrix.file_end }}
 
       - name: Release turncat binary
-        uses: svenstaro/upload-release-action@v2
+        uses: svenstaro/upload-release-action@29e53e917877a24fad85510ded594ab3c9ca12de
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: turncat-v${{ steps.vars.outputs.tag }}-${{ matrix.os }}-${{ matrix.arch }}${{ matrix.file_end }}
@@ -60,7 +60,7 @@
           asset_name: turncat-v${{ steps.vars.outputs.tag }}-${{ matrix.os }}-${{ matrix.arch }}${{ matrix.file_end }}
 
       - name: Release stunnerctl binary
-        uses: svenstaro/upload-release-action@v2
+        uses: svenstaro/upload-release-action@29e53e917877a24fad85510ded594ab3c9ca12de
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: stunnerctl-v${{ steps.vars.outputs.tag }}-${{ matrix.os }}-${{ matrix.arch }}${{ matrix.file_end }}
```

</details>

### `.github/workflows/publish--push-charts.yml`

- 🟠 MED `benc-uk/workflow-dispatch` (job `push_charts`)
- 🟠 MED `benc-uk/workflow-dispatch` (job `push_charts`)

<details>
<summary>Diff</summary>

```diff
--- a/.github/workflows/publish--push-charts.yml
+++ b/.github/workflows/publish--push-charts.yml
@@ -20,7 +20,7 @@
 
       - name: Trigger release workflow in the stunner-helm repo
         if: ${{ inputs.dev == false || inputs.dev == 'false' }}
-        uses: benc-uk/workflow-dispatch@v1
+        uses: benc-uk/workflow-dispatch@31e2b3319479a63f0ab15bf800eff9e913504e26
         with:
           token: ${{ secrets.WEB_PAT_TOKEN }}
           repo: l7mp/stunner-helm
@@ -29,7 +29,7 @@
 
       - name: Trigger release workflow in the stunner-helm repo
         if: ${{ inputs.dev == true || inputs.dev == 'true' }}
-        uses: benc-uk/workflow-dispatch@v1
+        uses: benc-uk/workflow-dispatch@31e2b3319479a63f0ab15bf800eff9e913504e26
         with:
           token: ${{ secrets.WEB_PAT_TOKEN }}
           repo: l7mp/stunner-helm
```

</details>

### `.github/workflows/publish-dev.yaml`

- 🟠 MED `docker/metadata-action` (job `push_stunner_to_registry`)
- 🟠 MED `docker/setup-qemu-action` (job `push_stunner_to_registry`)
- 🟠 MED `docker/setup-buildx-action` (job `push_stunner_to_registry`)
- 🟠 MED `docker/login-action` (job `push_stunner_to_registry`)
- 🟠 MED `docker/build-push-action` (job `push_stunner_to_registry`)
- 🟠 MED `docker/metadata-action` (job `push_icetester_to_registry`)
- 🟠 MED `docker/setup-qemu-action` (job `push_icetester_to_registry`)
- 🟠 MED `docker/setup-buildx-action` (job `push_icetester_to_registry`)
- 🟠 MED `docker/login-action` (job `push_icetester_to_registry`)
- 🟠 MED `docker/build-push-action` (job `push_icetester_to_registry`)
- ⚪ LOW `actions/checkout` (job `push_stunner_to_registry`)
- ⚪ LOW `actions/checkout` (job `push_icetester_to_registry`)

<details>
<summary>Diff</summary>

```diff
--- a/.github/workflows/publish-dev.yaml
+++ b/.github/workflows/publish-dev.yaml
@@ -23,30 +23,30 @@
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9
         with:
           images: l7mp/stunnerd
           tags: |
             type=raw,value=dev
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee
         with:
           username: ${{ secrets.DOCKER_USER }}
           password: ${{ secrets.DOCKER_TOKEN }}
 
       - name: Build and Push
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf
         with:
           context: .
           platforms: linux/amd64,linux/arm64
@@ -70,30 +70,30 @@
... (36 more diff lines — see Files changed)
```

</details>

### `.github/workflows/publish.yml`

- 🟠 MED `docker/metadata-action` (job `push_stunner_to_registry`)
- 🟠 MED `docker/setup-qemu-action` (job `push_stunner_to_registry`)
- 🟠 MED `docker/setup-buildx-action` (job `push_stunner_to_registry`)
- 🟠 MED `docker/login-action` (job `push_stunner_to_registry`)
- 🟠 MED `docker/build-push-action` (job `push_stunner_to_registry`)
- 🟠 MED `docker/metadata-action` (job `push_icetester_to_registry`)
- 🟠 MED `docker/setup-qemu-action` (job `push_icetester_to_registry`)
- 🟠 MED `docker/setup-buildx-action` (job `push_icetester_to_registry`)
- 🟠 MED `docker/login-action` (job `push_icetester_to_registry`)
- 🟠 MED `docker/build-push-action` (job `push_icetester_to_registry`)
- ⚪ LOW `actions/checkout` (job `check_release_readme`)
- ⚪ LOW `actions/checkout` (job `push_stunner_to_registry`)
- ⚪ LOW `actions/checkout` (job `push_icetester_to_registry`)

<details>
<summary>Diff</summary>

```diff
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,7 @@
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
 
       - name: Verify README is release-ready
         run: |
@@ -35,11 +35,11 @@
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9
         with:
           images: l7mp/stunnerd
           tags: |
@@ -47,19 +47,19 @@
             type=raw,value=latest
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee
         with:
... (47 more diff lines — see Files changed)
```

</details>

### `.github/workflows/test.yml`

- 🟠 MED `coverallsapp/github-action` (job `test`)
- 🟠 MED `anchore/scan-action` (job `seccheck`)
- ⚪ LOW `actions/checkout` (job `test`)
- ⚪ LOW `actions/setup-go` (job `test`)
- ⚪ LOW `actions/checkout` (job `seccheck`)

<details>
<summary>Diff</summary>

```diff
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,9 +19,9 @@
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
         with:
           go-version: '1.26'
       - name: Download modules
@@ -31,7 +31,7 @@
       - name: Test
         run: go test -v -covermode=count -coverprofile=coverage.out
       - name: Coveralls
-        uses: coverallsapp/github-action@v2
+        uses: coverallsapp/github-action@5cbfd81b66ca5d10c19b062c04de0199c215fb6e
         if: github.repository == 'l7mp/stunner'
         with:
           github-token: ${{ secrets.github_token }}
@@ -42,9 +42,9 @@
     runs-on: ubuntu-latest
     needs: [test]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
       - name: Check security vulnerabilites
-        uses: anchore/scan-action@v7
+        uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2
         with:
           path: "."
           fail-build: true
```

</details>


---

_Have other repositories you'd like analysed? Request a scan at [codeopsai.com](https://codeopsai.com)._

---

_AI-generated. Review the diff before merging._
