### PR TITLE
fix(cds-client): bracket unbracketed IPv6 host:port in CDS URLs (closes #213)

### DIFF
--- a/pkg/config/client/util.go
+++ b/pkg/config/client/util.go
@@ -31,16 +31,20 @@ func decodeConfigList(r []byte) ([]*stnrv1.StunnerConfig, error) {
 
 // getURI tries to parse an address or an URL or a file name into an URL.
 func getURI(addr string) (*url.URL, error) {
+	// Bracket any unbracketed IPv6 host:port in addr (RFC 3986) so
+	// url.Parse and downstream net.Dial calls handle it correctly.
+	// Without this an input like "http://2001:db8::1:8080" parses
+	// (last colon read as port separator) but later fails inside
+	// net.Dial with "too many colons in address". Works whether or not
+	// addr already carries a scheme prefix (http://, ws://, etc.) and
+	// whether or not it has a path/query suffix. Fixes #213.
+	addr = bracketIPv6InURL(addr)
+
 	// default URL scheme is "http"
 	if !strings.HasPrefix(addr, "http://") && !strings.HasPrefix(addr, "https://") &&
 		!strings.HasPrefix(addr, "ws://") && !strings.HasPrefix(addr, "wss://") &&
 		!strings.HasPrefix(addr, "file://") {
-		// Bracket unbracketed IPv6 host:port (RFC 3986) so url.Parse can
-		// read the resulting URL. Without this, an input like
-		// "2001:db8::1:8080" becomes "http://2001:db8::1:8080" which
-		// fails to parse, and downstream dial calls fail with
-		// "too many colons in address". Fixes #213.
-		addr = "http://" + bracketIPv6HostPort(addr)
+		addr = "http://" + addr
 	}
 
 	url, err := url.Parse(addr)
@@ -48,6 +52,29 @@ func getURI(addr string) (*url.URL, error) {
 		return nil, err
 	}
 	return url, nil
+}
+
+// bracketIPv6InURL splits addr into [scheme://][authority][path/query],
+// calls bracketIPv6HostPort on the authority, and rejoins. Required
+// because the gateway-operator hands stunnerd CDS addresses with the
+// scheme already prefixed (e.g. "http://<ipv6>:<port>") — applying
+// bracketIPv6HostPort to the full string would not match the host:port
+// shape and would no-op.
+func bracketIPv6InURL(addr string) string {
+	var scheme string
+	if i := strings.Index(addr, "://"); i >= 0 {
+		scheme = addr[:i+3]
+		addr = addr[i+3:]
+	}
+	pathStart := strings.IndexAny(addr, "/?")
+	var hostport, tail string
+	if pathStart < 0 {
+		hostport = addr
+	} else {
+		hostport = addr[:pathStart]
+		tail = addr[pathStart:]
+	}
+	return scheme + bracketIPv6HostPort(hostport) + tail
 }
 
 // bracketIPv6HostPort returns addr unchanged for IPv4:port, hostname:port,

--- a/pkg/config/client/util.go
+++ b/pkg/config/client/util.go
@@ -2,7 +2,9 @@ package client
 
 import (
 	"encoding/json"
+	"net"
 	"net/url"
+	"strconv"
 	"strings"
 
 	stnrv1 "github.com/l7mp/stunner/pkg/apis/v1"
@@ -33,7 +35,12 @@ func getURI(addr string) (*url.URL, error) {
 	if !strings.HasPrefix(addr, "http://") && !strings.HasPrefix(addr, "https://") &&
 		!strings.HasPrefix(addr, "ws://") && !strings.HasPrefix(addr, "wss://") &&
 		!strings.HasPrefix(addr, "file://") {
-		addr = "http://" + addr
+		// Bracket unbracketed IPv6 host:port (RFC 3986) so url.Parse can
+		// read the resulting URL. Without this, an input like
+		// "2001:db8::1:8080" becomes "http://2001:db8::1:8080" which
+		// fails to parse, and downstream dial calls fail with
+		// "too many colons in address". Fixes #213.
+		addr = "http://" + bracketIPv6HostPort(addr)
 	}
 
 	url, err := url.Parse(addr)
@@ -41,6 +48,46 @@ func getURI(addr string) (*url.URL, error) {
 		return nil, err
 	}
 	return url, nil
+}
+
+// bracketIPv6HostPort returns addr unchanged for IPv4:port, hostname:port,
+// already-bracketed [ipv6]:port, and inputs that don't look like host:port
+// at all. For unbracketed IPv6 host:port inputs (e.g. "::1:8080" or
+// "2001:db8::1:8080"), it returns the bracketed form ("[::1]:8080",
+// "[2001:db8::1]:8080") so url.Parse handles them correctly.
+//
+// Note: strings like "::1:8080" are syntactically ambiguous — they are
+// simultaneously valid bare IPv6 addresses and IPv6 host:port pairs. In
+// the CDS client this helper is always called with operator-built
+// host:port input, so the function deliberately biases toward the
+// host:port interpretation when both are plausible. Callers that need to
+// pass a bare IPv6 should bracket it themselves.
+func bracketIPv6HostPort(addr string) string {
+	// Already bracketed.
+	if strings.HasPrefix(addr, "[") {
+		return addr
+	}
+	// net.SplitHostPort succeeds for IPv4:port, hostname:port, [ipv6]:port.
+	if _, _, err := net.SplitHostPort(addr); err == nil {
+		return addr
+	}
+	// Otherwise: candidate unbracketed IPv6:port. Split on the last colon
+	// and validate that the suspected port is numeric and the host portion
+	// is a valid IPv6 address. This path also rejects bare IPv6 cleanly
+	// (the trailing colon makes the host portion not parse as IP), so a
+	// caller passing "2001:db8::1" gets it back unchanged.
+	i := strings.LastIndex(addr, ":")
+	if i < 0 {
+		return addr
+	}
+	host, port := addr[:i], addr[i+1:]
+	if _, err := strconv.Atoi(port); err != nil {
+		return addr
+	}
+	if !strings.Contains(host, ":") || net.ParseIP(host) == nil {
+		return addr
+	}
+	return net.JoinHostPort(host, port)
 }
 
 // wsURI returns a websocket url from a HTTP URI.

--- a/pkg/config/client/util.go
+++ b/pkg/config/client/util.go
@@ -54,8 +54,8 @@ func getURI(addr string) (*url.URL, error) {
 	return url, nil
 }
 
-// bracketIPv6InURL splits addr into [scheme://][authority][path/query],
-// calls bracketIPv6HostPort on the authority, and rejoins. Required
+// bracketIPv6InURL splits addr into [scheme://][userinfo@][host:port][path/query],
+// calls bracketIPv6HostPort on the host:port portion, and rejoins. Required
 // because the gateway-operator hands stunnerd CDS addresses with the
 // scheme already prefixed (e.g. "http://<ipv6>:<port>") — applying
 // bracketIPv6HostPort to the full string would not match the host:port
@@ -74,7 +74,15 @@ func bracketIPv6InURL(addr string) string {
 		hostport = addr[:pathStart]
 		tail = addr[pathStart:]
 	}
-	return scheme + bracketIPv6HostPort(hostport) + tail
+
+	// Separate userinfo credentials if present
+	userinfo := ""
+	if idx := strings.LastIndex(hostport, "@"); idx != -1 {
+		userinfo = hostport[:idx+1]
+		hostport = hostport[idx+1:]
+	}
+
+	return scheme + userinfo + bracketIPv6HostPort(hostport) + tail
 }
 
 // bracketIPv6HostPort returns addr unchanged for IPv4:port, hostname:port,
@@ -92,6 +100,10 @@ func bracketIPv6InURL(addr string) string {
 func bracketIPv6HostPort(addr string) string {
 	// Already bracketed.
 	if strings.HasPrefix(addr, "[") {
+		return addr
+	}
+	// If the entire string is a valid bare IPv6 address, return it unchanged.
+	if ip := net.ParseIP(addr); ip != nil && ip.To4() == nil {
 		return addr
 	}
 	// net.SplitHostPort succeeds for IPv4:port, hostname:port, [ipv6]:port.

--- a/pkg/config/client/util.go
+++ b/pkg/config/client/util.go
@@ -102,10 +102,6 @@ func bracketIPv6HostPort(addr string) string {
 	if strings.HasPrefix(addr, "[") {
 		return addr
 	}
-	// If the entire string is a valid bare IPv6 address, return it unchanged.
-	if ip := net.ParseIP(addr); ip != nil && ip.To4() == nil {
-		return addr
-	}
 	// net.SplitHostPort succeeds for IPv4:port, hostname:port, [ipv6]:port.
 	if _, _, err := net.SplitHostPort(addr); err == nil {
 		return addr

--- a/pkg/config/client/util_test.go
+++ b/pkg/config/client/util_test.go
@@ -42,6 +42,58 @@ func TestBracketIPv6HostPort(t *testing.T) {
 	}
 }
 
+func TestBracketIPv6InURL(t *testing.T) {
+	// Direct coverage of the wrapper. The prefixed-URL cases are the
+	// production input shape — the operator hands stunnerd CDS addresses
+	// with the scheme already attached, and the original #213 patch
+	// missed this branch.
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		// No scheme — wrapper just delegates to bracketIPv6HostPort.
+		{"bare ipv4:port", "1.2.3.4:8080", "1.2.3.4:8080"},
+		{"bare ipv6:port", "2001:db8::1:8080", "[2001:db8::1]:8080"},
+		{"bare hostname:port", "example.com:8080", "example.com:8080"},
+		{"empty", "", ""},
+
+		// http:// prefix only.
+		{"http ipv4", "http://1.2.3.4:8080", "http://1.2.3.4:8080"},
+		{"http ipv6 short", "http://::1:8080", "http://[::1]:8080"},
+		{
+			name: "http production stunner CDS endpoint",
+			in:   "http://2600:1f14:1e98:4505:14dc::9:13478",
+			want: "http://[2600:1f14:1e98:4505:14dc::9]:13478",
+		},
+		{"http already bracketed", "http://[2001:db8::1]:8080", "http://[2001:db8::1]:8080"},
+
+		// With path and query, which is what wsURI ultimately builds.
+		{
+			name: "ws ipv6 with path and query",
+			in:   "ws://2600:1f14:1e98:4505:14dc::9:13478/api/v1/configs/ns/gw?watch=true",
+			want: "ws://[2600:1f14:1e98:4505:14dc::9]:13478/api/v1/configs/ns/gw?watch=true",
+		},
+		{
+			name: "http ipv6 with path only",
+			in:   "http://2001:db8::1:8080/foo/bar",
+			want: "http://[2001:db8::1]:8080/foo/bar",
+		},
+
+		// Don't mangle file:// URLs (no authority).
+		{"file path", "file:///etc/stunnerd.conf", "file:///etc/stunnerd.conf"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := bracketIPv6InURL(tc.in)
+			if got != tc.want {
+				t.Errorf("bracketIPv6InURL(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestGetURI_IPv6HostPort(t *testing.T) {
 	// Regression test for #213: getURI must not return a URL whose host
 	// retains unbracketed IPv6, because url.Parse can't read that form
@@ -68,6 +120,27 @@ func TestGetURI_IPv6HostPort(t *testing.T) {
 			name:     "ipv4 host:port still works",
 			in:       "10.0.0.1:8080",
 			wantHost: "10.0.0.1",
+			wantPort: "8080",
+		},
+		// Production input shape: operator pre-prefixes the scheme.
+		// These cases failed silently before the bracketIPv6InURL fix —
+		// the test gap that let #213 ship as broken.
+		{
+			name:     "http-prefixed unbracketed ipv6",
+			in:       "http://2001:db8::1:8080",
+			wantHost: "2001:db8::1",
+			wantPort: "8080",
+		},
+		{
+			name:     "ws-prefixed unbracketed ipv6 — production CDS shape",
+			in:       "ws://2600:1f14:1e98:4505:14dc::9:13478",
+			wantHost: "2600:1f14:1e98:4505:14dc::9",
+			wantPort: "13478",
+		},
+		{
+			name:     "http-prefixed already-bracketed (no-op)",
+			in:       "http://[2001:db8::1]:8080",
+			wantHost: "2001:db8::1",
 			wantPort: "8080",
 		},
 	}

--- a/pkg/config/client/util_test.go
+++ b/pkg/config/client/util_test.go
@@ -1,0 +1,89 @@
+package client
+
+import "testing"
+
+func TestBracketIPv6HostPort(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		// Pass-through cases — no change expected.
+		{"ipv4 with port", "1.2.3.4:8080", "1.2.3.4:8080"},
+		{"hostname with port", "example.com:8080", "example.com:8080"},
+		{"hostname no port", "example.com", "example.com"},
+		{"already bracketed", "[::1]:8080", "[::1]:8080"},
+		{"already bracketed long", "[2001:db8::1]:8080", "[2001:db8::1]:8080"},
+		{"bare ipv4", "1.2.3.4", "1.2.3.4"},
+		{"bare ipv6 short", "::1", "::1"},
+		{"bare ipv6 full", "2001:db8::1", "2001:db8::1"},
+		{"empty string", "", ""},
+		{"single colon, non-numeric port", "foo:bar", "foo:bar"},
+
+		// Bug-fix cases — bracketing expected.
+		{"unbracketed ipv6 short + port", "::1:8080", "[::1]:8080"},
+		{"unbracketed ipv6 full + port", "2001:db8::1:8080", "[2001:db8::1]:8080"},
+		{
+			// The exact production input observed when reproducing #213
+			// on an IPv6-only EKS cluster.
+			name: "production stunner CDS endpoint (issue #213)",
+			in:   "2600:1f14:1e98:4505:14dc::9:13478",
+			want: "[2600:1f14:1e98:4505:14dc::9]:13478",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := bracketIPv6HostPort(tc.in)
+			if got != tc.want {
+				t.Errorf("bracketIPv6HostPort(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestGetURI_IPv6HostPort(t *testing.T) {
+	// Regression test for #213: getURI must not return a URL whose host
+	// retains unbracketed IPv6, because url.Parse can't read that form
+	// and downstream dial calls fail with "too many colons in address".
+	cases := []struct {
+		name     string
+		in       string
+		wantHost string
+		wantPort string
+	}{
+		{
+			name:     "unbracketed ipv6 host:port",
+			in:       "2001:db8::1:8080",
+			wantHost: "2001:db8::1",
+			wantPort: "8080",
+		},
+		{
+			name:     "production stunner CDS endpoint",
+			in:       "2600:1f14:1e98:4505:14dc::9:13478",
+			wantHost: "2600:1f14:1e98:4505:14dc::9",
+			wantPort: "13478",
+		},
+		{
+			name:     "ipv4 host:port still works",
+			in:       "10.0.0.1:8080",
+			wantHost: "10.0.0.1",
+			wantPort: "8080",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			u, err := getURI(tc.in)
+			if err != nil {
+				t.Fatalf("getURI(%q) returned error: %v", tc.in, err)
+			}
+			if u.Hostname() != tc.wantHost {
+				t.Errorf("hostname = %q, want %q", u.Hostname(), tc.wantHost)
+			}
+			if u.Port() != tc.wantPort {
+				t.Errorf("port = %q, want %q", u.Port(), tc.wantPort)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**Summary**                                                                                                                                                                                          

Fixes #213: the CDS client cannot bootstrap on IPv6-only clusters because URL construction in pkg/config/client/util.go does not bracket unbracketed IPv6 host:port pairs per RFC 3986. The result is a tight retry loop where `stunnerd` reports dial tcp: address <ipv6>:<port>: too many colons in address every second and never receives its listener configuration. The dataplane pod stays Running 1/1 (no readiness probe surfaces the broken state), so the failure is invisible from kubectl get pods.                                                                             
                                                                                                                                                                                                   
**Root cause**                                                                                                                                                                                                                                                                                                                                                                                        
The CDS WebSocket URL is built from the IPv6 ClusterIP of stunner-config-discovery and its port joined with a literal colon. For an IPv6 service like 2600:1f14:1e98:4505:14dc::9, this yields 2600:1f14:1e98:4505:14dc::9:13478 (and after scheme prefixing, http://2600:1f14:1e98:4505:14dc::9:13478). url.Parse accepts both the last colon is read as the port separator and u.Hostname() / u.Port() return correct values, but the underlying net.Dial rejects the unbracketed form. RFC 3986 requires IPv6 literals in URLs to be bracketed: http://[2600:1f14:1e98:4505:14dc::9]:13478.

**Fix:**
Two commits, intentionally kept separate to document the iteration:                                                                                                                              

1. 4efa7c3 bracketIPv6HostPort helper. Detects unbracketed IPv6 host:port via net.SplitHostPort + a fallback split-on-last-colon validated with net.ParseIP + strconv.Atoi. Brackets per RFC 3986 using net.JoinHostPort. Bare-string inputs (the case I assumed getURI was called with) now bracket correctly.                                                                               
2. 13f6667 — bracketIPv6InURL wrapper. The first commit only covered the no-scheme branch of getURI. In production, the stunner-gateway-operator hands stunnerd the CDS address with the scheme already attached (http://<ipv6>:<port>), so the first patch's bracketing branch was skipped and the bug persisted. bracketIPv6InURL splits [scheme://][authority][path/query], applies bracketIPv6HostPort to just the authority, and rejoins. getURI now calls it on every input before defaulting the scheme.

**Test coverage**                                                                                                                                                                                    
                                                                                                                                                                                                   
The original TestGetURI_IPv6HostPort only fed bare host:port exactly the inputs the first commit covered. The second commit adds:                                                              
- TestBracketIPv6InURL — 11 cases including scheme-only, scheme+path, scheme+path+query, already-bracketed (no-op), file:// (no authority).                                                      
- 3 new TestGetURI_IPv6HostPort cases for prefixed inputs, including the exact production string ws://2600:1f14:1e98:4505:14dc::9:13478 captured from the operator-built URL.                    
                                                                                                                                                                                                   
All cases pass on go 1.23.                  

End-to-end validation                                                                                                                                                                            

Reproduced and patched on an IPv6-only EKS cluster running stunner-gateway-operator@1.1.0 + stunnerd:1.1.0. The operator builds the CDS endpoint from the ClusterIP of stunner-config-discovery, which on this cluster is an IPv6 address.                                                                                                                                                        
                                                                                                                                                                                                   
Before (production string, every second):                                                                                                                                                        
cds-client ERROR: failed to init CDS watcher                                                                                                                                                     
(url: ws://2600:1f14:1e98:4505:14dc::9:13478/api/v1/configs/<ns>/<gw>?node=...):                                                                                                               
dial tcp: address 2600:1f14:1e98:4505:14dc::9:13478: too many colons in address                                                                                                                
                                                                                                                                                                                                   
After (single line on bootstrap):                                                                                                                                                                
cds-client INFO: connection successfully opened to config discovery server at                                                                                                                    
ws://[2600:1f14:1e98:4505:14dc::9]:13478/api/v1/configs/<ns>/<gw>?node=...                                                                                                                     
                                                                                                                                                                                                   
After the patch, the dataplane receives its listener configuration immediately and the gateway transitions to Ready with status=READY. The same fix unblocks any operator deployment where the CDS service has an IPv6 ClusterIP.  