### PR TITLE
feat: expand listener configs with comma separated addrs into multiple listeners

### DIFF
--- a/pkg/apis/v1/stunner.go
+++ b/pkg/apis/v1/stunner.go
@@ -36,16 +36,22 @@ func (req *StunnerConfig) Validate() error {
 		return err
 	}
 
-	if req.Listeners == nil {
-		req.Listeners = []ListenerConfig{}
-	} else {
-		for i, l := range req.Listeners {
-			if err := l.Validate(); err != nil {
+	expandedListeners := []ListenerConfig{}
+	for _, l := range req.Listeners {
+		addrs := strings.Split(l.Addr, ",")
+		for i, addr := range addrs {
+			newListener := l
+			if len(addrs) > 1 {
+				newListener.Name = fmt.Sprintf("%s-%d", newListener.Name, i)
+			}
+			newListener.Addr = addr
+			if err := newListener.Validate(); err != nil {
 				return err
 			}
-			req.Listeners[i] = l
+			expandedListeners = append(expandedListeners, newListener)
 		}
 	}
+	req.Listeners = expandedListeners
 
 	if req.Clusters == nil {
 		req.Clusters = []ClusterConfig{}


### PR DESCRIPTION
This is a small change that allows the `address` field of the listener config to contain a comma separated list of addresses. In this case that listener gets turned into a separate listener (with the rest of the config of the listener left the same) for each of those addresses.

The reason behind wanting to do this is for dual stack deployments on k8s. Right now, stunner relies on the operator creating a config that uses the `status.podIP` field ref from the downward api in an environment var. However, in a dual stack setup, that listener should probably be listening on all the pod ips, not just whichever one gets chosen by k8s. The full list of pod ips is exposed, as `status.podIPs` which is a comma separated list of all the pod ips. Hence this proposal - with this the operator could just set the STUNNER_ADDR var to `status.podIPs` and this will expand that one listener config out to listen on each of those pod ips.

On the one hand I do realize this feels perhaps like a bit of a hack, however, this was the best way I could come up with to get this to work, at least without doing something much more complicated.