### PR TITLE
fix: use net.JoinHostPort to handle ipv6 addresses

### DIFF
--- a/internal/object/listener.go
+++ b/internal/object/listener.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net"
 	"sort"
+	"strconv"
 	"strings"
 	"sync/atomic"
 
@@ -201,8 +202,8 @@ func (l *Listener) buildConfig() *stnrv1.ListenerConfig {
 
 // String returns a short stable representation, safe as a map key.
 func (l *Listener) String() string {
-	return fmt.Sprintf("%s: [%s://%s:%d<%d:%d>]", l.name, strings.ToLower(l.proto.String()),
-		l.addr, l.port, l.minPort, l.maxPort)
+	return fmt.Sprintf("%s: [%s://%s<%d:%d>]", l.name, strings.ToLower(l.proto.String()),
+		net.JoinHostPort(l.addr.String(), strconv.Itoa(l.port)), l.minPort, l.maxPort)
 }
 
 // GetConfig returns a copy of the live listener config. Safe for concurrent use.

--- a/pkg/apis/v1/listener.go
+++ b/pkg/apis/v1/listener.go
@@ -2,8 +2,10 @@ package v1
 
 import (
 	"fmt"
+	"net"
 	"reflect"
 	"sort"
+	"strconv"
 	"strings"
 )
 
@@ -111,7 +113,7 @@ func (req *ListenerConfig) String() string {
 		addr = req.Addr
 	}
 
-	status = append(status, fmt.Sprintf("turn://%s:%d?transport=%s", addr, req.Port, req.Protocol))
+	status = append(status, fmt.Sprintf("turn://%s?transport=%s", net.JoinHostPort(addr, strconv.Itoa(req.Port)), req.Protocol))
 
 	a, p := "-", "-"
 	if req.PublicAddr != "" {
@@ -177,9 +179,9 @@ func (req *ListenerConfig) GetListenerURI(rfc7065 bool) (string, error) {
 
 	var uri string
 	if rfc7065 {
-		uri = fmt.Sprintf("%s:%s:%d?transport=%s", service, addr, port, protocol)
+		uri = fmt.Sprintf("%s:%s?transport=%s", service, net.JoinHostPort(addr, strconv.Itoa(port)), protocol)
 	} else {
-		uri = fmt.Sprintf("%s://%s:%d?transport=%s", service, addr, port, protocol)
+		uri = fmt.Sprintf("%s://%s?transport=%s", service, net.JoinHostPort(addr, strconv.Itoa(port)), protocol)
 	}
 	return uri, nil
 }

--- a/pkg/config/client/k8s_client.go
+++ b/pkg/config/client/k8s_client.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"os"
 	"strconv"
@@ -176,7 +177,7 @@ func DiscoverK8sCDSServer(ctx context.Context, k8sFlags *cliopt.ConfigFlags, cds
 	// if CDS server address is specified, return it
 	if cdsFlags.Addr != "" {
 		return PodInfo{
-			Addr:  fmt.Sprintf("%s:%d", cdsFlags.Addr, cdsFlags.Port),
+			Addr:  net.JoinHostPort(cdsFlags.Addr, strconv.Itoa(cdsFlags.Port)),
 			Proxy: false,
 		}, nil
 	}
@@ -224,7 +225,7 @@ func DiscoverK8sStunnerdPods(ctx context.Context, k8sFlags *cliopt.ConfigFlags, 
 	// direct connection
 	if podFlags.Addr != "" {
 		return []PodInfo{{
-			Addr:  fmt.Sprintf("%s:%d", podFlags.Addr, podFlags.Port),
+			Addr:  net.JoinHostPort(podFlags.Addr, strconv.Itoa(podFlags.Port)),
 			Proxy: false,
 		}}, nil
 	}


### PR DESCRIPTION
There's a bunch of places where a host and port are joined with something like `fmt.Sprintf("%s:%d", r.Address, requestedPort)`. This doesn't work for ipv6 addresses as those have colons in them, so you can end up with a joined string like `::1:443` given an address `::1` and port `443` for example - this is obviously wrong and can cause issues in ipv6 only or dual-stack setups. I've tried to identify as many of the places this is happening and replace them with `net.JoinHostPort(addr, port)` which properly puts the brackets around the ipv6 address (while leaving ipv4 addresses handled pretty much the same way), which for the prior example would result in `[::1]:443`.